### PR TITLE
Loading state when awaiting llm responses

### DIFF
--- a/apps/backroad-example/src/main.ts
+++ b/apps/backroad-example/src/main.ts
@@ -5,7 +5,7 @@ const initialMessages = [
   { by: 'ai', content: 'Hi, how can I help you today? 😀' },
 ];
 run(
-  async (br) => {
+  (br) => {
     pages.fileUpload(br.page({ path: '/file-upload' }));
     const page2 = br.page({ path: '/page-2' });
     page2.write({ body: 'hello from page 2' });

--- a/apps/backroad-example/src/main.ts
+++ b/apps/backroad-example/src/main.ts
@@ -1,28 +1,29 @@
-import { run } from '@backroad/backroad';
+import { run, ChatManager } from '@backroad/backroad';
 import { pages } from './pages';
 
 const initialMessages = [
   { by: 'ai', content: 'Hi, how can I help you today? 😀' },
 ];
 run(
-  (br) => {
+  async (br) => {
     pages.fileUpload(br.page({ path: '/file-upload' }));
     const page2 = br.page({ path: '/page-2' });
     page2.write({ body: 'hello from page 2' });
     // const br = brBase.base({});
-    const messages = br.getOrDefault('messages', initialMessages);
     br.write({ body: `# Backroad LLM Example\n---` });
     const button = br.button({ label: 'Reset' });
-    messages.forEach((message) => {
-      br.chatMessage({ name: message.by }).write({ body: message.content });
+    const chatManager = new ChatManager({
+      br,
+      messagesStateName: 'messages',
+      initialMessages,
+      inputId: 'input',
     });
-    const input = br.chatInput({ id: 'input' });
-    if (input) {
-      br.setValue('messages', [
-        ...messages,
-        { by: 'human', content: input },
-        { by: 'ai', content: getGPTResponse(input) },
-      ]);
+
+    if (chatManager.userInputComplete) {
+      const gptResponsePromise = getGPTResponse(
+        chatManager.userInput as string
+      );
+      chatManager.addAIMessage({ by: 'ai', content: gptResponsePromise });
     }
 
     if (button) {
@@ -37,11 +38,18 @@ run(
   }
 );
 
-const getGPTResponse = (message: string) => {
+const getGPTResponse = async (message: string) => {
+  await simulatedDelay();
   if (message.includes('1+1')) {
     return 'Ah, the answer to that is 2!! 😎';
   } else {
     return `I don't know...
     ![i-dont-know](https://t3.ftcdn.net/jpg/05/66/80/74/360_F_566807496_uKCQoOWWdXbFWKluJXo2ilg7B61J0qIe.jpg)`;
   }
+};
+
+const simulatedDelay = () => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 3000);
+  });
 };

--- a/apps/backroad-example/src/pages/llm.ts
+++ b/apps/backroad-example/src/pages/llm.ts
@@ -6,7 +6,7 @@ export const backroadLLMExample = async (br: BackroadNodeManager) => {
   ]);
   br.write({ body: `# LLM Example\n---` });
   messages.forEach((message) => {
-    br.chatMessage({ name: message.by }).write({ body: message.content });
+    br.chatMessage({ by: message.by }).write({ body: message.content });
   });
   const input = br.chatInput({ id: 'input' });
   if (input) {

--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -16,3 +16,90 @@
 .backroad-label {
   @apply font-medium label-text;
 }
+
+.loader {
+  display: block;
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  position: relative;
+  text-indent: -9999em;
+  animation: mulShdSpin 1.1s infinite ease;
+  transform: translateZ(0);
+}
+@keyframes mulShdSpin {
+  0%,
+  100% {
+    box-shadow: 0em -2.6em 0em 0em #ffffff,
+      1.8em -1.8em 0 0em rgba(255, 255, 255, 0.2),
+      2.5em 0em 0 0em rgba(255, 255, 255, 0.2),
+      1.75em 1.75em 0 0em rgba(255, 255, 255, 0.2),
+      0em 2.5em 0 0em rgba(255, 255, 255, 0.2),
+      -1.8em 1.8em 0 0em rgba(255, 255, 255, 0.2),
+      -2.6em 0em 0 0em rgba(255, 255, 255, 0.5),
+      -1.8em -1.8em 0 0em rgba(255, 255, 255, 0.7);
+  }
+  12.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(255, 255, 255, 0.7),
+      1.8em -1.8em 0 0em #ffffff, 2.5em 0em 0 0em rgba(255, 255, 255, 0.2),
+      1.75em 1.75em 0 0em rgba(255, 255, 255, 0.2),
+      0em 2.5em 0 0em rgba(255, 255, 255, 0.2),
+      -1.8em 1.8em 0 0em rgba(255, 255, 255, 0.2),
+      -2.6em 0em 0 0em rgba(255, 255, 255, 0.2),
+      -1.8em -1.8em 0 0em rgba(255, 255, 255, 0.5);
+  }
+  25% {
+    box-shadow: 0em -2.6em 0em 0em rgba(255, 255, 255, 0.5),
+      1.8em -1.8em 0 0em rgba(255, 255, 255, 0.7), 2.5em 0em 0 0em #ffffff,
+      1.75em 1.75em 0 0em rgba(255, 255, 255, 0.2),
+      0em 2.5em 0 0em rgba(255, 255, 255, 0.2),
+      -1.8em 1.8em 0 0em rgba(255, 255, 255, 0.2),
+      -2.6em 0em 0 0em rgba(255, 255, 255, 0.2),
+      -1.8em -1.8em 0 0em rgba(255, 255, 255, 0.2);
+  }
+  37.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(255, 255, 255, 0.2),
+      1.8em -1.8em 0 0em rgba(255, 255, 255, 0.5),
+      2.5em 0em 0 0em rgba(255, 255, 255, 0.7), 1.75em 1.75em 0 0em #ffffff,
+      0em 2.5em 0 0em rgba(255, 255, 255, 0.2),
+      -1.8em 1.8em 0 0em rgba(255, 255, 255, 0.2),
+      -2.6em 0em 0 0em rgba(255, 255, 255, 0.2),
+      -1.8em -1.8em 0 0em rgba(255, 255, 255, 0.2);
+  }
+  50% {
+    box-shadow: 0em -2.6em 0em 0em rgba(255, 255, 255, 0.2),
+      1.8em -1.8em 0 0em rgba(255, 255, 255, 0.2),
+      2.5em 0em 0 0em rgba(255, 255, 255, 0.5),
+      1.75em 1.75em 0 0em rgba(255, 255, 255, 0.7), 0em 2.5em 0 0em #ffffff,
+      -1.8em 1.8em 0 0em rgba(255, 255, 255, 0.2),
+      -2.6em 0em 0 0em rgba(255, 255, 255, 0.2),
+      -1.8em -1.8em 0 0em rgba(255, 255, 255, 0.2);
+  }
+  62.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(255, 255, 255, 0.2),
+      1.8em -1.8em 0 0em rgba(255, 255, 255, 0.2),
+      2.5em 0em 0 0em rgba(255, 255, 255, 0.2),
+      1.75em 1.75em 0 0em rgba(255, 255, 255, 0.5),
+      0em 2.5em 0 0em rgba(255, 255, 255, 0.7), -1.8em 1.8em 0 0em #ffffff,
+      -2.6em 0em 0 0em rgba(255, 255, 255, 0.2),
+      -1.8em -1.8em 0 0em rgba(255, 255, 255, 0.2);
+  }
+  75% {
+    box-shadow: 0em -2.6em 0em 0em rgba(255, 255, 255, 0.2),
+      1.8em -1.8em 0 0em rgba(255, 255, 255, 0.2),
+      2.5em 0em 0 0em rgba(255, 255, 255, 0.2),
+      1.75em 1.75em 0 0em rgba(255, 255, 255, 0.2),
+      0em 2.5em 0 0em rgba(255, 255, 255, 0.5),
+      -1.8em 1.8em 0 0em rgba(255, 255, 255, 0.7), -2.6em 0em 0 0em #ffffff,
+      -1.8em -1.8em 0 0em rgba(255, 255, 255, 0.2);
+  }
+  87.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(255, 255, 255, 0.2),
+      1.8em -1.8em 0 0em rgba(255, 255, 255, 0.2),
+      2.5em 0em 0 0em rgba(255, 255, 255, 0.2),
+      1.75em 1.75em 0 0em rgba(255, 255, 255, 0.2),
+      0em 2.5em 0 0em rgba(255, 255, 255, 0.2),
+      -1.8em 1.8em 0 0em rgba(255, 255, 255, 0.5),
+      -2.6em 0em 0 0em rgba(255, 255, 255, 0.7), -1.8em -1.8em 0 0em #ffffff;
+  }
+}

--- a/libs/backroad-client/src/lib/components/index.tsx
+++ b/libs/backroad-client/src/lib/components/index.tsx
@@ -25,6 +25,7 @@ import { Radio } from './radio';
 import { FileUpload } from './file_upload';
 import { TextInput } from './text_input';
 import { Video } from './video';
+import { LoadingSpinner } from './loading_spinner';
 
 export const backroadClientComponents: {
   [key in InbuiltComponentTypes]: (
@@ -51,7 +52,6 @@ export const backroadClientComponents: {
 
   chat_input: ChatInput,
 
-
   color_picker: ColorPicker,
   toggle: Toggle,
   checkbox: Checkbox,
@@ -64,5 +64,6 @@ export const backroadClientComponents: {
   button: Button,
 
   image: Image,
-  video: Video
+  video: Video,
+  loading_spinner: LoadingSpinner,
 };

--- a/libs/backroad-client/src/lib/components/loading_spinner.tsx
+++ b/libs/backroad-client/src/lib/components/loading_spinner.tsx
@@ -1,0 +1,8 @@
+import { BackroadComponentRenderer } from '../types/components';
+
+export const LoadingSpinner: BackroadComponentRenderer<'loading_spinner'> = (
+  props
+) => {
+  const { fontSize, top, left } = props.args;
+  return <span style={{ fontSize, top, left }} className="loader"></span>;
+};

--- a/libs/backroad-client/src/lib/containers/chat_message.tsx
+++ b/libs/backroad-client/src/lib/containers/chat_message.tsx
@@ -1,19 +1,72 @@
-import { CpuChipIcon, UserIcon } from "@heroicons/react/24/outline"
-import { BackroadContainerRenderer } from "../types/containers"
-import { Base } from "./base"
-const leftAlignClasses = "flex-row text-left"
-const rightAlignClasses = "flex-row-reverse !text-right"
+import { CpuChipIcon, UserIcon } from '@heroicons/react/24/outline';
+import { BackroadContainerRenderer } from '../types/containers';
+import { Base } from './base';
+import { LoadingSpinner } from '../components/loading_spinner';
+import { useEffect, useState } from 'react';
+import { socket } from '../socket';
+import { BackroadContainer } from '@backroad/core';
+const leftAlignClasses = 'flex-row text-left';
+const rightAlignClasses = 'flex-row-reverse !text-right';
 
-export const ChatMessage: BackroadContainerRenderer<"chat_message"> = (props) => {
-    return <div className={`flex gap-3 items-start ${props.args.avatarPlacement ? { "left": leftAlignClasses, "right": rightAlignClasses }[props.args.avatarPlacement] : (props.args.name ? {
-        "ai": leftAlignClasses, "human": rightAlignClasses
-    }[props.args.name] : leftAlignClasses)}`}>
-        <div className="bg-primary text-primary-content p-3 rounded-xl">
-            {props.args.avatar ? <img src={props.args.avatar} alt={`${props.args.name} message`} /> : { ai: <CpuChipIcon width={24} />, human: <UserIcon width={24} /> }[props.args.name]}
-        </div>
-        <div className="flex-1">
-            <Base {...{ ...props, type: "base" }} />
-            {/* {props.children.map(child => <TreeRender tree={child} key={child.path} />)} */}
-        </div>
+export const ChatMessage: BackroadContainerRenderer<'chat_message'> = (
+  props
+) => {
+  const [loading, setLoading] = useState(
+    props.args.loadingPromise !== undefined
+  );
+
+  useEffect(() => {
+    const handlePropsChange = (
+      changedProps: BackroadContainer<'chat_message', true>['args'],
+      callback: () => void
+    ) => {
+      if (!changedProps.loadingPromise && loading) {
+        setLoading(false);
+      }
+      callback();
+    };
+    socket.on('props_change', handlePropsChange);
+    return () => {
+      socket.off('props_change', handlePropsChange);
+    };
+  }, [loading]);
+  return (
+    <div
+      className={`flex gap-3 items-start ${
+        props.args.avatarPlacement
+          ? { left: leftAlignClasses, right: rightAlignClasses }[
+              props.args.avatarPlacement
+            ]
+          : props.args.by
+          ? {
+              ai: leftAlignClasses,
+              human: rightAlignClasses,
+            }[props.args.by]
+          : leftAlignClasses
+      }`}
+    >
+      <div className="bg-primary text-primary-content p-3 rounded-xl">
+        {props.args.avatar ? (
+          <img src={props.args.avatar} alt={`${props.args.by} message`} />
+        ) : (
+          { ai: <CpuChipIcon width={24} />, human: <UserIcon width={24} /> }[
+            props.args.by
+          ]
+        )}
+      </div>
+      <div className="flex-1">
+        <Base {...{ ...props, type: 'base' }} />
+        {/* {props.children.map(child => <TreeRender tree={child} key={child.path} />)} */}
+        {loading && (
+          <LoadingSpinner
+            path={props.path}
+            id={props.path}
+            type="loading_spinner"
+            value={null}
+            args={{ fontSize: 6.5, top: 21, left: 18 }}
+          />
+        )}
+      </div>
     </div>
-}
+  );
+};

--- a/libs/backroad-core/src/lib/core.ts
+++ b/libs/backroad-core/src/lib/core.ts
@@ -185,6 +185,14 @@ type _ComponentBasePropsMapping = {
     args: HTMLProps<HTMLVideoElement>;
     value: null;
   };
+  loading_spinner: {
+    args: {
+      fontSize: number;
+      top?: number;
+      left?: number;
+    };
+    value: null;
+  };
   // date_input: AllowDefaultHelper<{}>
 };
 export type ComponentPropsMapping = {
@@ -220,7 +228,21 @@ type ContainerArgsMapping = {
     };
   };
   chat_message: {
-    args: { name: string; avatar?: string; avatarPlacement?: 'left' | 'right' };
+    args: {
+      by: string;
+      avatar?: string;
+      avatarPlacement?: 'left' | 'right';
+      loadingPromise?: Promise<string>;
+    };
+  };
+};
+export type ManagerArgsMapping = {
+  chat_manager: {
+    args: {
+      messages: (ContainerArgsMapping['chat_message']['args'] & {
+        content: string | Promise<string>;
+      })[];
+    };
   };
 };
 export type InbuiltComponentTypes = keyof ComponentPropsMapping;

--- a/libs/backroad-core/src/lib/events.ts
+++ b/libs/backroad-core/src/lib/events.ts
@@ -25,7 +25,11 @@ type ConstructSocketIoEventSignatureFromBackroadEvents<
     callback: (callBackArgs: BackroadEventsMapping[key]['response']) => void
   ) => void;
 };
-export type ServerToClientEventTypes = 'render' | 'running' | 'backroad_config';
+export type ServerToClientEventTypes =
+  | 'render'
+  | 'running'
+  | 'backroad_config'
+  | 'props_change';
 export type ClientToServerEvents =
   ConstructSocketIoEventSignatureFromBackroadEvents<ClientToServerEventTypes>;
 export type ServerToClientEvents =
@@ -49,6 +53,10 @@ export type BackroadEventsMapping = {
   };
   running: {
     args: null;
+    response?: void;
+  };
+  props_change: {
+    args: any;
     response?: void;
   };
   config: {

--- a/libs/backroad/src/index.ts
+++ b/libs/backroad/src/index.ts
@@ -1,4 +1,4 @@
 // export { startBackroadServer } from './lib/server';
 export { run } from './lib/runner';
-export { BackroadNodeManager } from './lib/backroad';
+export { BackroadNodeManager, ChatManager } from './lib/backroad';
 export { Config } from './lib/server/server-socket-event-handlers/types';

--- a/libs/backroad/src/lib/backroad/backroad.ts
+++ b/libs/backroad/src/lib/backroad/backroad.ts
@@ -201,6 +201,11 @@ export class BackroadNodeManager<
     );
   }
   chatMessage(props: BackroadContainerFormat<'chat_message'>) {
+    props.loadingPromise?.then(() => {
+      this.backroadSession.renderQueue.updateProps({
+        loadingPromise: undefined,
+      });
+    });
     return this.#addContainerDescendant(
       this.#constructContainerObject(props, 'chat_message')
     );
@@ -211,6 +216,9 @@ export class BackroadNodeManager<
   }
   linkGroup(props: BackroadComponentFormat<'link_group'>) {
     return this.#initialiseAndAddComponentDescendant(props, 'link_group');
+  }
+  loading(props: BackroadComponentFormat<'loading_spinner'>) {
+    return this.#initialiseAndAddComponentDescendant(props, 'loading_spinner');
   }
   stats(props: BackroadComponentFormat<'stats'>) {
     return this.#initialiseAndAddComponentDescendant(props, 'stats');

--- a/libs/backroad/src/lib/backroad/chat-manager.ts
+++ b/libs/backroad/src/lib/backroad/chat-manager.ts
@@ -1,0 +1,93 @@
+import { type BackroadNodeManager } from '../backroad';
+import { type ManagerArgsMapping } from '@backroad/core';
+
+type ChatManagerProps = {
+  br: BackroadNodeManager<'page'>;
+  messagesStateName: string;
+  initialMessages: ManagerArgsMapping['chat_manager']['args']['messages'];
+  inputId: string;
+};
+
+export class ChatManager {
+  private br: ChatManagerProps['br'];
+  private messagesStateName: ChatManagerProps['messagesStateName'];
+  private initialMessages: ChatManagerProps['initialMessages'];
+  private messages: ChatManagerProps['initialMessages'];
+  private inputId: string;
+  userInput: string | null;
+  userInputComplete: boolean;
+  awaitingLlmResponse = false;
+  constructor(props: ChatManagerProps) {
+    this.br = props.br;
+    this.messagesStateName = props.messagesStateName;
+    this.initialMessages = props.initialMessages;
+    this.inputId = props.inputId;
+    this.messages = props.br.getOrDefault(
+      props.messagesStateName,
+      props.initialMessages
+    );
+    this.userInput = null;
+    this.userInputComplete = false;
+    this.initialize(props.inputId);
+  }
+  private initialize(inputId: string) {
+    if (
+      !this.messages.every(
+        (message) => message.by === 'ai' || message.by === 'human'
+      )
+    ) {
+      throw new Error('All chat messages must be by either "ai" or "human"');
+    }
+    this.messages
+      .filter((message) => typeof message.content === 'string')
+      .forEach(({ by, content }) => {
+        this.br.chatMessage({ by }).write({ body: content as string });
+      });
+
+    // Only show chat input if the last message was from an llm
+    if (this.messages.slice(-1)[0].by === 'ai') {
+      this.userInput = this.br.chatInput({ id: inputId });
+    }
+
+    if (this.userInput) {
+      this.br.setValue(this.messagesStateName, [
+        ...this.messages,
+        { by: 'human', content: this.userInput },
+      ]);
+    } else if (this.messages.slice(-1)[0].by === 'human') {
+      this.userInputComplete = true;
+      this.userInput = this.messages.slice(-1)[0].content as string;
+    }
+  }
+
+  addAIMessage(
+    message: ManagerArgsMapping['chat_manager']['args']['messages'][0]
+  ) {
+    const chatMessage = this.br.chatMessage({
+      by: message.by,
+      loadingPromise:
+        typeof message.content !== 'string' ? message.content : undefined,
+    });
+    this.userInput = this.br.chatInput({ id: this.inputId });
+    if (typeof message.content !== 'string') {
+      message.content.then((body) => {
+        this.br.setValue(this.messagesStateName, [
+          ...this.messages,
+          { ...message, content: body },
+        ]);
+        this.messages = this.br.getOrDefault(
+          this.messagesStateName,
+          this.initialMessages
+        );
+        chatMessage.write({ body });
+      });
+    } else {
+      this.br.setValue(this.messagesStateName, [...this.messages, message]);
+      this.messages = this.br.getOrDefault(
+        this.messagesStateName,
+        this.initialMessages
+      );
+      chatMessage.write({ body: message.content });
+    }
+  }
+}

--- a/libs/backroad/src/lib/backroad/index.ts
+++ b/libs/backroad/src/lib/backroad/index.ts
@@ -1,1 +1,2 @@
 export { BackroadNodeManager } from './backroad';
+export { ChatManager } from './chat-manager';

--- a/libs/backroad/src/lib/backroad/render-queue.ts
+++ b/libs/backroad/src/lib/backroad/render-queue.ts
@@ -29,4 +29,10 @@ export class RenderQueue {
       console.log('batched render request acked by frontend');
     });
   }
+  updateProps(props: any) {
+    const socket = SocketManager.getSocket(this.backroadSession.sessionId);
+    socket.emit('props_change', props, () => {
+      console.log('props change request acked by frontend');
+    });
+  }
 }


### PR DESCRIPTION
I was noticing that backroad can only support synchronous llm responses, which is not a realistic scenario given llm requests don't provide immediate replies. This one was tough to implement and not sure this is the best strategy, but it gets the job done and looks great on the UI. Open to make changes, as I'm sure I didn't follow a pattern or two. Thanks