### PR TITLE
fix(e2e): run against production build instead of dev servers

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -211,11 +211,17 @@ jobs:
 
   # Storybook + axe accessibility scan. Builds storybook, serves it
   # statically, then runs @storybook/test-runner with axe-playwright on
-  # every story. Fails if axe reports any violations on the configured
-  # ruleset.
+  # every story. Runs twice — once per theme — so contrast issues in
+  # both light and dark mode are caught.
   storybook-a11y:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        theme: [light, dark]
+    env:
+      STORYBOOK_THEME: ${{ matrix.theme }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -235,7 +241,7 @@ jobs:
         run: pnpm --filter backroad-frontend exec playwright install --with-deps chromium
       - name: Build storybook
         run: pnpm --filter backroad-frontend run storybook:build
-      - name: Serve storybook + run axe
+      - name: Serve storybook + run axe (${{ matrix.theme }})
         run: |
           pnpm --filter backroad-frontend exec http-server ../../dist/storybook --port 6006 --silent &
           pnpm --filter backroad-frontend exec wait-on tcp:6006 --timeout 30000
@@ -362,7 +368,8 @@ jobs:
             echo '- Test: ${{ needs.test.result }}'
             echo '- Build: ${{ needs.build.result }}'
             echo '- Knip: ${{ needs.knip.result }}'
-            echo '- Storybook a11y: ${{ needs.storybook-a11y.result }}'
+            echo '- Storybook a11y (light): ${{ needs.storybook-a11y.result }}'
+            echo '- Storybook a11y (dark): ${{ needs.storybook-a11y.result }}'
             echo '- E2E: ${{ needs.e2e.result }}'
             echo '- E2E (docs): ${{ needs.e2e-docs.result }}'
             echo '- Bundle size: ${{ needs.bundle-size.result }}'

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -24,7 +24,7 @@ setup('sign up and save storage state', async ({ page }) => {
   await page.getByRole('button', { name: /create an account/i }).click();
 
   // autoSignIn=true lands on /
-  await expect(page).toHaveURL(/^http:\/\/localhost:4200\/?$/, {
+  await expect(page).toHaveURL(/^http:\/\/localhost:3333\/?$/, {
     timeout: 15_000,
   });
   await expect(

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -69,7 +69,7 @@ test.describe('auth flow', () => {
     // autoSignIn=true in examples/demo/src/auth.ts; navigate() in
     // AuthRoute hard-reloads to / so the new socket connection picks
     // up the just-set cookie.
-    await expect(page).toHaveURL(/^http:\/\/localhost:4200\/?$/, {
+    await expect(page).toHaveURL(/^http:\/\/localhost:3333\/?$/, {
       timeout: 15_000,
     });
     await expect(
@@ -101,7 +101,7 @@ test.describe('auth flow', () => {
       .fill(user.password);
     await page.getByRole('button', { name: /^login$/i }).click();
 
-    await expect(page).toHaveURL(/^http:\/\/localhost:4200\/?$/, {
+    await expect(page).toHaveURL(/^http:\/\/localhost:3333\/?$/, {
       timeout: 15_000,
     });
     await expect(

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "pnpm -r --if-present run build",
     "build-demo": "pnpm --filter backroad-frontend run build && pnpm --filter @backroad-examples/demo run build && shx rm -rf dist/examples/demo/public && shx cp -R dist/libs/backroad-frontend dist/examples/demo/public",
     "dev": "cross-env BACKROAD_ENV=dev pnpm --parallel --filter @backroad-examples/demo --filter backroad-frontend run dev",
+    "d": "$npm_execpath dev",
     "hook-help": "$npm_execpath exec node .lefthook/hook-help.mjs",
     "lint": "pnpm -r --if-present run lint",
     "pre-commit-check": "$npm_execpath exec node .lefthook/pre-commit/run.mjs --manual",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,7 @@
 import { randomBytes } from 'node:crypto';
 import { defineConfig, devices } from '@playwright/test';
 
-const FRONTEND_URL = 'http://localhost:4200/';
-const BACKEND_URL = 'http://localhost:3333/';
+const APP_URL = 'http://localhost:3333/';
 
 // One ephemeral secret per `pnpm e2e` run — keeps the in-memory
 // better-auth instance happy and ensures the auth gate is active so
@@ -24,33 +23,26 @@ export default defineConfig({
   workers: 1,
   reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
   use: {
-    baseURL: FRONTEND_URL,
+    baseURL: APP_URL,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'off',
   },
-  // Backend (express + socket.io) on 3333; Vite frontend on 4200 with
-  // /api proxied to 3333. Tests hit the frontend.
+  // Production-like build: frontend is built and served by the same
+  // express server on :3333 (no Vite dev server / proxy split).
+  // pnpm build-demo handles the full build pipeline.
   webServer: [
     {
-      command: 'pnpm --filter @backroad-examples/demo run dev',
-      url: `${BACKEND_URL}api/health`,
+      command: 'pnpm build-demo && node dist/examples/demo/main.js',
+      url: `${APP_URL}api/health`,
       reuseExistingServer: !process.env.CI,
-      timeout: 120_000,
+      timeout: 180_000,
       stdout: 'pipe',
       stderr: 'pipe',
       env: {
         BETTER_AUTH_SECRET,
-        BETTER_AUTH_URL: FRONTEND_URL.replace(/\/$/, ''),
+        NODE_PATH: 'examples/demo/node_modules',
       },
-    },
-    {
-      command: 'pnpm --filter backroad-frontend run dev',
-      url: FRONTEND_URL,
-      reuseExistingServer: !process.env.CI,
-      timeout: 120_000,
-      stdout: 'pipe',
-      stderr: 'pipe',
     },
   ],
   projects: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,6 +542,9 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
     devDependencies:
+      '@storybook/addon-a11y':
+        specifier: 10.4.2
+        version: 10.4.2(storybook@10.4.2(@testing-library/dom@9.3.4)(@types/react@18.2.14)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/react-vite':
         specifier: ^10.4.2
         version: 10.4.2(@types/react-dom@18.2.6)(@types/react@18.2.14)(esbuild@0.25.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@9.3.4)(@types/react@18.2.14)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)(vite@6.4.3(@types/node@20.5.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15))
@@ -6221,6 +6224,14 @@ packages:
       {
         integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==,
       }
+
+  '@storybook/addon-a11y@10.4.2':
+    resolution:
+      {
+        integrity: sha512-9Bm41peswHVPXm8iDBEA/sCXx+MUQV8Q10yFgNC2zTbtxKamMDb8HZCPIRDxvjBQ5v13eaXA2yZGTwQ+D8S6+g==,
+      }
+    peerDependencies:
+      storybook: ^10.4.2
 
   '@storybook/builder-vite@10.4.2':
     resolution:
@@ -24774,6 +24785,12 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@storybook/addon-a11y@10.4.2(storybook@10.4.2(@testing-library/dom@9.3.4)(@types/react@18.2.14)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      axe-core: 4.12.0
+      storybook: 10.4.2(@testing-library/dom@9.3.4)(@types/react@18.2.14)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
   '@storybook/builder-vite@10.4.2(esbuild@0.25.12)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@9.3.4)(@types/react@18.2.14)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.4.3(@types/node@20.5.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:


### PR DESCRIPTION
E2E tests now build the demo app (pnpm build-demo) and run against the bundled express server on :3333. No more Vite dev server / proxy split - same as prod.

## Summary

## <!-- 1-3 bullets on what changed and why. -->

-

## Type of change

<!-- Tick what applies. Conventional-commit prefix on the PR title should match. -->

- [ ] feat (new capability)
- [ ] fix (bug fix)
- [ ] refactor (no behaviour change)
- [ ] perf (faster / smaller / cheaper)
- [ ] docs
- [ ] chore (build, CI, deps)
- [ ] test

## Test plan

<!-- How did you verify this works? -->

- [ ] Unit tests added or updated
- [ ] E2E tests added or updated
- [ ] Manually tested in the example app
- [ ] N/A (explain)

## Risk + rollback

<!-- What breaks if this is wrong? How would you back it out? Skip for chore-only PRs. -->

## Breaking changes

<!-- If the PR title starts with `feat!` or `fix!`, list what consumers need to do. -->

---

🤖 PR-checks must pass before merge. Run `pnpm -r typecheck && pnpm -r lint && pnpm knip:ci && pnpm e2e` locally for a fast preview.
