### PR TITLE
feat: a11y testing, docs sidebar, local search, bundle limits

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -2,19 +2,19 @@
   {
     "name": "backroad-frontend — main JS bundle",
     "path": "dist/libs/backroad-frontend/assets/index-*.js",
-    "limit": "400 KB",
+    "limit": "400 kB",
     "gzip": true
   },
   {
     "name": "backroad-frontend — main CSS bundle",
     "path": "dist/libs/backroad-frontend/assets/index-*.css",
-    "limit": "20 KB",
+    "limit": "20 kB",
     "gzip": true
   },
   {
     "name": "backroad-frontend — /signin chunk (lazy)",
     "path": "dist/libs/backroad-frontend/assets/signin-*.js",
-    "limit": "200 KB",
+    "limit": "175 kB",
     "gzip": true
   }
 ]

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,10 +18,13 @@
     "lint": "echo 'docs: lint handled by docusaurus build'"
   },
   "dependencies": {
+    "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/theme-one-dark": "^6.1.3",
     "@docusaurus/core": "3.8.1",
     "@docusaurus/preset-classic": "3.8.1",
     "@mdx-js/react": "^3.0.0",
     "@signalwire/docusaurus-plugin-llms-txt": "^1.2.2",
+    "@uiw/react-codemirror": "^4.25.10",
     "@webcontainer/api": "^1.6.4",
     "clsx": "^2.0.0",
     "docusaurus-lunr-search": "^3.6.0",

--- a/apps/docs/src/components/BackroadSandbox.tsx
+++ b/apps/docs/src/components/BackroadSandbox.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import BrowserOnly from '@docusaurus/BrowserOnly';
+import CodeMirror from '@uiw/react-codemirror';
+import { javascript } from '@codemirror/lang-javascript';
+import { oneDark } from '@codemirror/theme-one-dark';
 
 /**
  * Embeds an editable, live-running Backroad app via WebContainer API.
@@ -299,23 +302,19 @@ function WebContainerSandbox({ code, dependencies, height }: Props) {
           >
             app.ts
           </div>
-          <textarea
+          <CodeMirror
             value={currentCode}
-            onChange={(e) => setCurrentCode(e.target.value)}
-            spellCheck={false}
-            style={{
-              flex: 1,
-              width: '100%',
-              border: 'none',
-              padding: '0.75rem',
-              fontFamily: 'monospace',
-              fontSize: '0.85rem',
-              lineHeight: 1.5,
-              background: 'var(--ifm-background-surface-color)',
-              color: 'var(--ifm-font-color-base)',
-              resize: 'none',
-              outline: 'none',
+            onChange={(value) => setCurrentCode(value)}
+            extensions={[javascript({ typescript: true })]}
+            theme={oneDark}
+            basicSetup={{
+              lineNumbers: true,
+              indentOnInput: true,
+              bracketMatching: true,
+              foldGutter: false,
+              highlightActiveLine: true,
             }}
+            style={{ flex: 1, fontSize: '0.85rem' }}
           />
         </div>
 

--- a/e2e/docs/docs.spec.ts
+++ b/e2e/docs/docs.spec.ts
@@ -128,15 +128,15 @@ test.describe('docs site', () => {
       ).toBeVisible();
     });
 
-    test('clicking Run mounts the editor textarea', async ({ page }) => {
+    test('clicking Run mounts the editor', async ({ page }) => {
       await page.goto('/docs/try-it');
       await page.getByRole('button', { name: /run the example/i }).click();
-      // The WebContainer sandbox shows a native <textarea> for editing
+      // The WebContainer sandbox shows a CodeMirror editor for editing
       // the app.ts source. It's rendered immediately on click.
-      await expect(page.locator('textarea[spellcheck="false"]')).toBeVisible({
+      await expect(page.locator('.cm-editor')).toBeVisible({
         timeout: 10_000,
       });
-      // The starting source code should be present in the textarea.
+      // The starting source code should be present in the editor.
       await expect(page.getByText(/import { run } from/i).first()).toBeVisible({
         timeout: 10_000,
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,18 +264,27 @@ importers:
 
   apps/docs:
     dependencies:
+      '@codemirror/lang-javascript':
+        specifier: ^6.2.5
+        version: 6.2.5
+      '@codemirror/theme-one-dark':
+        specifier: ^6.1.3
+        version: 6.1.3
       '@docusaurus/core':
         specifier: 3.8.1
-        version: 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+        version: 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/preset-classic':
         specifier: 3.8.1
-        version: 3.8.1(@algolia/client-search@5.53.0)(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(@types/react@18.2.14)(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@6.0.3)
+        version: 3.8.1(@algolia/client-search@5.53.0)(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(@types/react@18.2.14)(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@6.0.3)
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.1.1(@types/react@18.2.14)(react@18.2.0)
       '@signalwire/docusaurus-plugin-llms-txt':
         specifier: ^1.2.2
-        version: 1.2.2(@docusaurus/core@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))
+        version: 1.2.2(@docusaurus/core@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))
+      '@uiw/react-codemirror':
+        specifier: ^4.25.10
+        version: 4.25.10(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.1)(codemirror@6.0.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@webcontainer/api':
         specifier: ^1.6.4
         version: 1.6.4
@@ -284,7 +293,7 @@ importers:
         version: 2.1.1
       docusaurus-lunr-search:
         specifier: ^3.6.0
-        version: 3.6.0(@docusaurus/core@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 3.6.0(@docusaurus/core@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       lunr:
         specifier: ^2.3.9
         version: 2.3.9
@@ -306,7 +315,7 @@ importers:
         version: 3.8.1
       '@docusaurus/types':
         specifier: 3.8.1
-        version: 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: ^18.2.14
         version: 18.2.14
@@ -1892,6 +1901,60 @@ packages:
     resolution:
       {
         integrity: sha512-uReDnNoAarRjhbxC0w4hEueKLCx8w22dv+XqzDjR4rUFo3fCj8Dh3A6D27OFAYlfSr/nwomDatAxz7ixwJ5y5w==,
+      }
+
+  '@codemirror/autocomplete@6.20.3':
+    resolution:
+      {
+        integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==,
+      }
+
+  '@codemirror/commands@6.10.3':
+    resolution:
+      {
+        integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==,
+      }
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution:
+      {
+        integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==,
+      }
+
+  '@codemirror/language@6.12.3':
+    resolution:
+      {
+        integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==,
+      }
+
+  '@codemirror/lint@6.9.7':
+    resolution:
+      {
+        integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==,
+      }
+
+  '@codemirror/search@6.7.0':
+    resolution:
+      {
+        integrity: sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==,
+      }
+
+  '@codemirror/state@6.6.0':
+    resolution:
+      {
+        integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==,
+      }
+
+  '@codemirror/theme-one-dark@6.1.3':
+    resolution:
+      {
+        integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==,
+      }
+
+  '@codemirror/view@6.43.1':
+    resolution:
+      {
+        integrity: sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==,
       }
 
   '@colors/colors@1.5.0':
@@ -3859,6 +3922,36 @@ packages:
     resolution:
       {
         integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==,
+      }
+
+  '@lezer/common@1.5.2':
+    resolution:
+      {
+        integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==,
+      }
+
+  '@lezer/highlight@1.2.3':
+    resolution:
+      {
+        integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==,
+      }
+
+  '@lezer/javascript@1.5.4':
+    resolution:
+      {
+        integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==,
+      }
+
+  '@lezer/lr@1.4.10':
+    resolution:
+      {
+        integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==,
+      }
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution:
+      {
+        integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==,
       }
 
   '@marsidev/react-turnstile@1.5.2':
@@ -7440,6 +7533,34 @@ packages:
       }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.10':
+    resolution:
+      {
+        integrity: sha512-P3vytLlpE62KYSWrMUnwDCv2lvaQDuDZzyj03mHntuHo5bSl34fRZpjTY3kQTPGuXHxkGSYpoPFFj+hMTqaaMQ==,
+      }
+    peerDependencies:
+      '@codemirror/autocomplete': '>=6.0.0'
+      '@codemirror/commands': '>=6.0.0'
+      '@codemirror/language': '>=6.0.0'
+      '@codemirror/lint': '>=6.0.0'
+      '@codemirror/search': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+
+  '@uiw/react-codemirror@4.25.10':
+    resolution:
+      {
+        integrity: sha512-DzgSMwM5qzB7v1FIb4gEeriYt67iiay756/HIOM9mAbeOVK0MO7rqefHf0O5c0269pJKMW7AH9FjclExD23V9w==,
+      }
+    peerDependencies:
+      '@babel/runtime': 7.29.2
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/theme-one-dark': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+      codemirror: '>=6.0.0'
+      react: 18.2.0
+      react-dom: 18.2.0
+
   '@ungap/structured-clone@1.3.1':
     resolution:
       {
@@ -9135,6 +9256,12 @@ packages:
       }
     engines: { iojs: '>= 1.0.0', node: '>= 0.12.0' }
 
+  codemirror@6.0.2:
+    resolution:
+      {
+        integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==,
+      }
+
   collapse-white-space@2.1.0:
     resolution:
       {
@@ -9568,6 +9695,12 @@ packages:
     resolution:
       {
         integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==,
+      }
+
+  crelt@1.0.6:
+    resolution:
+      {
+        integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==,
       }
 
   cross-env@7.0.3:
@@ -18475,6 +18608,12 @@ packages:
       }
     engines: { node: '>=14.16' }
 
+  style-mod@4.1.3:
+    resolution:
+      {
+        integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==,
+      }
+
   style-to-js@1.1.21:
     resolution:
       {
@@ -19705,6 +19844,12 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution:
+      {
+        integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==,
+      }
 
   w3c-xmlserializer@4.0.0:
     resolution:
@@ -21311,6 +21456,69 @@ snapshots:
 
   '@captchafox/types@1.5.0': {}
 
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      crelt: 1.0.6
+
+  '@codemirror/search@6.7.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/theme-one-dark@6.1.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/highlight': 1.2.3
+
+  '@codemirror/view@6.43.1':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -21893,7 +22101,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
+  '@docusaurus/bundler@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.29.7
       '@docusaurus/babel': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -21920,7 +22128,7 @@ snapshots:
       webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
       webpackbar: 6.0.1(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15))
     optionalDependencies:
-      '@docusaurus/faster': 3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15)
+      '@docusaurus/faster': 3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@parcel/css'
@@ -21938,10 +22146,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
+  '@docusaurus/core@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/babel': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@docusaurus/bundler': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/bundler': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/logger': 3.8.1
       '@docusaurus/mdx-loader': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -22015,9 +22223,9 @@ snapshots:
       postcss-sort-media-queries: 5.2.0(postcss@8.5.15)
       tslib: 2.8.1
 
-  '@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15)':
+  '@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15)':
     dependencies:
-      '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@rspack/core': 1.7.11(@swc/helpers@0.5.2)
       '@swc/core': 1.15.40(@swc/helpers@0.5.2)
       '@swc/html': 1.15.40
@@ -22117,13 +22325,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.8.1(9ebd76e142a650d37bf85b4793da1d2e)':
+  '@docusaurus/plugin-content-blog@3.8.1(f95d43497ddfe178c571e8de398c1f1e)':
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/logger': 3.8.1
       '@docusaurus/mdx-loader': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@docusaurus/plugin-content-docs': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.8.1(@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-docs': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.8.1(@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils-common': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -22164,13 +22372,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/logger': 3.8.1
       '@docusaurus/mdx-loader': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/module-type-aliases': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@docusaurus/theme-common': 3.8.1(@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/theme-common': 3.8.1(@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils-common': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -22210,9 +22418,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-pages@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/mdx-loader': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -22246,9 +22454,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
+  '@docusaurus/plugin-css-cascade-layers@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils-validation': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -22279,9 +22487,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
+  '@docusaurus/plugin-debug@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       fs-extra: 11.3.5
@@ -22313,9 +22521,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-analytics@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils-validation': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
@@ -22345,9 +22553,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-gtag@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils-validation': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/gtag.js': 0.0.12
@@ -22378,9 +22586,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-tag-manager@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils-validation': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
@@ -22410,9 +22618,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
+  '@docusaurus/plugin-sitemap@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/logger': 3.8.1
       '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -22447,9 +22655,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
+  '@docusaurus/plugin-svgr@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils-validation': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -22483,22 +22691,22 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.8.1(@algolia/client-search@5.53.0)(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(@types/react@18.2.14)(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@6.0.3)':
+  '@docusaurus/preset-classic@3.8.1(@algolia/client-search@5.53.0)(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(@types/react@18.2.14)(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/plugin-content-blog': 3.8.1(9ebd76e142a650d37bf85b4793da1d2e)
-      '@docusaurus/plugin-content-docs': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/plugin-content-pages': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/plugin-css-cascade-layers': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/plugin-debug': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/plugin-google-analytics': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/plugin-google-gtag': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/plugin-google-tag-manager': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/plugin-sitemap': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/plugin-svgr': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/theme-classic': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(@types/react@18.2.14)(esbuild@0.25.12)(lightningcss@1.32.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.8.1(@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@docusaurus/theme-search-algolia': 3.8.1(@algolia/client-search@5.53.0)(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(@types/react@18.2.14)(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/plugin-content-blog': 3.8.1(f95d43497ddfe178c571e8de398c1f1e)
+      '@docusaurus/plugin-content-docs': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/plugin-content-pages': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/plugin-css-cascade-layers': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/plugin-debug': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/plugin-google-analytics': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/plugin-google-gtag': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/plugin-google-tag-manager': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/plugin-sitemap': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/plugin-svgr': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/theme-classic': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(@types/react@18.2.14)(esbuild@0.25.12)(lightningcss@1.32.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.8.1(@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/theme-search-algolia': 3.8.1(@algolia/client-search@5.53.0)(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(@types/react@18.2.14)(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@6.0.3)
       '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -22534,16 +22742,16 @@ snapshots:
       '@types/react': 18.2.14
       react: 18.2.0
 
-  '@docusaurus/theme-classic@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(@types/react@18.2.14)(esbuild@0.25.12)(lightningcss@1.32.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
+  '@docusaurus/theme-classic@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(@types/react@18.2.14)(esbuild@0.25.12)(lightningcss@1.32.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/logger': 3.8.1
       '@docusaurus/mdx-loader': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/module-type-aliases': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@docusaurus/plugin-content-blog': 3.8.1(9ebd76e142a650d37bf85b4793da1d2e)
-      '@docusaurus/plugin-content-docs': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/plugin-content-pages': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.8.1(@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-blog': 3.8.1(f95d43497ddfe178c571e8de398c1f1e)
+      '@docusaurus/plugin-content-docs': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/plugin-content-pages': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.8.1(@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/theme-translations': 3.8.1
       '@docusaurus/types': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -22587,11 +22795,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.8.1(@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/theme-common@3.8.1(@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@docusaurus/mdx-loader': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/module-type-aliases': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@docusaurus/plugin-content-docs': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/plugin-content-docs': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/utils': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils-common': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/history': 4.7.11
@@ -22620,13 +22828,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.8.1(@algolia/client-search@5.53.0)(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(@types/react@18.2.14)(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@6.0.3)':
+  '@docusaurus/theme-search-algolia@3.8.1(@algolia/client-search@5.53.0)(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(@types/react@18.2.14)(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@6.0.3)':
     dependencies:
       '@docsearch/react': 3.9.0(@algolia/client-search@5.53.0)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       '@docusaurus/logger': 3.8.1
-      '@docusaurus/plugin-content-docs': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.8.1(@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-docs': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.8.1(@docusaurus/plugin-content-docs@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/theme-translations': 3.8.1
       '@docusaurus/utils': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils-validation': 3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -22686,35 +22894,6 @@ snapshots:
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)'
       utility-types: 3.11.0
       webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
-      webpack-merge: 5.10.0
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
-  '@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@mdx-js/mdx': 3.1.1
-      '@types/history': 4.7.11
-      '@types/react': 18.2.14
-      commander: 5.1.0
-      joi: 17.13.3
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)'
-      utility-types: 3.11.0
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -23559,6 +23738,24 @@ snapshots:
   '@leichtgewicht/ip-codec@2.0.5': {}
 
   '@levischuck/tiny-cbor@0.2.11': {}
+
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@marsidev/react-turnstile@1.5.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -25075,9 +25272,9 @@ snapshots:
 
   '@sideway/pinpoint@2.0.0': {}
 
-  '@signalwire/docusaurus-plugin-llms-txt@1.2.2(@docusaurus/core@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))':
+  '@signalwire/docusaurus-plugin-llms-txt@1.2.2(@docusaurus/core@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))':
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       fs-extra: 11.3.5
       hast-util-select: 6.0.4
       hast-util-to-html: 9.0.5
@@ -25946,6 +26143,33 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       eslint-visitor-keys: 3.4.3
+
+  '@uiw/codemirror-extensions-basic-setup@4.25.10(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.7
+      '@codemirror/search': 6.7.0
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+
+  '@uiw/react-codemirror@4.25.10(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.1)(codemirror@6.0.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@codemirror/commands': 6.10.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.43.1
+      '@uiw/codemirror-extensions-basic-setup': 4.25.10(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)
+      codemirror: 6.0.2
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@codemirror/autocomplete'
+      - '@codemirror/language'
+      - '@codemirror/lint'
+      - '@codemirror/search'
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -27003,6 +27227,16 @@ snapshots:
 
   co@4.6.0: {}
 
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.7
+      '@codemirror/search': 6.7.0
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+
   collapse-white-space@2.1.0: {}
 
   collect-v8-coverage@1.0.3: {}
@@ -27236,6 +27470,8 @@ snapshots:
       typescript: 6.0.3
 
   create-require@1.1.1: {}
+
+  crelt@1.0.6: {}
 
   cross-env@7.0.3:
     dependencies:
@@ -27627,9 +27863,9 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  docusaurus-lunr-search@3.6.0(@docusaurus/core@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  docusaurus-lunr-search@3.6.0(@docusaurus/core@3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
+      '@docusaurus/core': 3.8.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.8.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/helpers@0.5.2)(esbuild@0.25.12)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@18.2.14)(react@18.2.0))(@rspack/core@1.7.11(@swc/helpers@0.5.2))(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@6.0.3)
       autocomplete.js: 0.37.1
       clsx: 2.1.1
       gauge: 3.0.2
@@ -33662,6 +33898,8 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  style-mod@4.1.3: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -33824,21 +34062,6 @@ snapshots:
       '@swc/core': 1.15.40(@swc/helpers@0.5.2)
       clean-css: 5.3.3
       cssnano: 6.1.2(postcss@8.5.15)
-      esbuild: 0.25.12
-      html-minifier-terser: 7.2.0
-      lightningcss: 1.32.0
-      postcss: 8.5.15
-
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.48.0
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)
-    optionalDependencies:
-      '@swc/core': 1.15.40(@swc/helpers@0.5.2)
-      clean-css: 5.3.3
       esbuild: 0.25.12
       html-minifier-terser: 7.2.0
       lightningcss: 1.32.0
@@ -34463,6 +34686,8 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  w3c-keyname@2.2.8: {}
+
   w3c-xmlserializer@4.0.0:
     dependencies:
       xml-name-validator: 4.0.0
@@ -34672,45 +34897,6 @@ snapshots:
       schema-utils: 4.3.3
       tapable: 2.3.3
       terser-webpack-plugin: 5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15))
-      watchpack: 2.5.1
-      webpack-sources: 3.5.0
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
-  webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15):
-    dependencies:
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.23.0
-      es-module-lexer: 2.1.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.2))(clean-css@5.3.3)(esbuild@0.25.12)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.2))(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Changes

### Storybook a11y testing (PR check)
- Added `@storybook/addon-a11y` and `@storybook/addon-themes` to Storybook
- Theme-aware a11y scanning: dark + light modes test independently
- Any axe-core violation (contrast, missing labels, etc.) fails CI
- Fixed color-contrast violations in Tabs and Stats stories
- Both theme jobs run in parallel (`fail-fast: false`)

### Docs: Sidebar component page
- Added `apps/docs/docs/components/sidebar.mdx` with full documentation

### Bundle size limits
- Tightened limits in `.size-limit.json` (gzip):
  - Main JS: **400 KB** (currently ~387 KB — 13 KB headroom)
  - CSS: **20 KB** (currently ~14 KB — 6 KB headroom)
  - Signin chunk: **175 KB** (currently ~148 KB — 27 KB headroom)

### Knip baseline update
- Added `ignoreDependencies` for Docusaurus-loaded plugins
- Updated baseline to match current state