### PR TITLE
feat: page-agnostic sidebar with currentPath + layout overflow fixes

### DIFF
--- a/e2e/sidebar.spec.ts
+++ b/e2e/sidebar.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 // Auth is handled by the "setup auth" project; the chromium project loads
 // the saved storage state so we are already logged in when these run.
@@ -6,19 +6,25 @@ import { expect, test } from '@playwright/test';
 const OPEN_SIDEBAR = /open sidebar/i;
 const CLOSE_SIDEBAR = /close sidebar/i;
 
-async function openSidebar(page: import('@playwright/test').Page) {
+// The ✕ close button lives inside the sidebar <nav> (role="navigation").
+// The full-screen backdrop is also an aria-labelled "Close sidebar" button,
+// so scope to the nav to avoid a strict-mode multiple-match.
+const navCloseButton = (page: Page) =>
+  page.getByRole('navigation').getByRole('button', { name: CLOSE_SIDEBAR });
+
+async function openSidebar(page: Page) {
   const btn = page.getByRole('button', { name: OPEN_SIDEBAR });
   await expect(btn).toBeVisible({ timeout: 10_000 });
   await btn.click();
-  await expect(page.getByRole('button', { name: CLOSE_SIDEBAR })).toBeVisible();
+  await expect(navCloseButton(page)).toBeVisible();
 }
 
 test.describe('sidebar sharing across pages', () => {
-  // This test uses in-app React Router navigation (clicking sidebar links),
-  // NOT page.goto, so the sidebar component stays mounted and we can verify
-  // it never unmounts across route changes — that is exactly what the fix
-  // guarantees.
-  test('sidebar stays mounted and open after navigating via a sidebar link', async ({
+  // The sidebar is a root-level node rendered outside <Routes>, so its content
+  // is shared on every page. It auto-closes on navigation (so the backdrop
+  // never lingers), but re-opening on the new route shows the same nav links —
+  // proving the content is shared, not re-declared per page.
+  test('sidebar content is shared after navigating via a sidebar link', async ({
     page,
   }) => {
     await page.goto('/');
@@ -28,16 +34,17 @@ test.describe('sidebar sharing across pages', () => {
     await expect(page.getByRole('link', { name: '🏠 Home' })).toBeVisible();
     await expect(page.getByRole('link', { name: '📐 Columns' })).toBeVisible();
 
-    // Navigate to /columns via the sidebar link (React Router — no page reload)
+    // Navigate to /columns via the sidebar link (React Router — no full reload)
     await page.getByRole('link', { name: '📐 Columns' }).click();
     await expect(page).toHaveURL(/\/columns/);
 
-    // Sidebar is still open — the component was NOT unmounted
-    await expect(page.getByRole('button', { name: CLOSE_SIDEBAR })).toBeVisible(
-      { timeout: 10_000 }
-    );
+    // Sidebar auto-closes on navigation: the open button is back
+    await expect(page.getByRole('button', { name: OPEN_SIDEBAR })).toBeVisible({
+      timeout: 10_000,
+    });
 
-    // Same nav links still present after navigation
+    // Re-open on the new route — the same shared nav links are present
+    await openSidebar(page);
     await expect(page.getByRole('link', { name: '🏠 Home' })).toBeVisible();
     await expect(page.getByRole('link', { name: '📐 Columns' })).toBeVisible();
   });
@@ -56,8 +63,9 @@ test.describe('sidebar sharing across pages', () => {
 });
 
 test.describe('per-path sidebar differentiation via currentPath', () => {
-  // Each page.goto triggers a fresh run with the correct currentPath, so
-  // the sidebar's path indicator reflects the active route.
+  // The sidebar renders a "📍 `<currentPath>`" indicator. Each full load and
+  // each in-app navigation triggers a run_script carrying the pathname, so the
+  // indicator reflects the active route.
   test('sidebar shows the current path on home', async ({ page }) => {
     await page.goto('/');
     await openSidebar(page);
@@ -75,15 +83,15 @@ test.describe('per-path sidebar differentiation via currentPath', () => {
   test('path indicator updates after in-app navigation', async ({ page }) => {
     await page.goto('/');
     await openSidebar(page);
-
-    // Home path shown
     await expect(page.getByText('📍')).toContainText('/', { timeout: 10_000 });
 
-    // Navigate to /charts via sidebar link
+    // Navigate to /charts via the sidebar link; the sidebar auto-closes.
     await page.getByRole('link', { name: '📊 Charts' }).click();
     await expect(page).toHaveURL(/\/charts/);
 
-    // Path indicator updates to /charts after the re-run triggered by navigate
+    // Re-open and confirm the indicator updated to the new route — proving the
+    // executor re-ran with the new currentPath.
+    await openSidebar(page);
     await expect(page.getByText('📍')).toContainText('/charts', {
       timeout: 10_000,
     });

--- a/libs/backroad-components/src/lib/components/markdown.tsx
+++ b/libs/backroad-components/src/lib/components/markdown.tsx
@@ -12,7 +12,13 @@ export const Markdown: BackroadComponentRenderer<'markdown'> = (props) => {
           a: (props) => {
             return <Link to={props.href || '/'}>{props.children}</Link>;
           },
-          pre: (props) => <pre className="overflow-x-auto" {...props} />,
+          // A horizontally scrollable <pre> must be keyboard-focusable so
+          // keyboard users can scroll it (axe rule scrollable-region-focusable).
+          // tabIndex alone satisfies this; a role/landmark is NOT added, since
+          // multiple same-named regions would trip landmark-unique.
+          pre: (props) => (
+            <pre className="overflow-x-auto" tabIndex={0} {...props} />
+          ),
         }}
       >
         {props.args.body.toString()}

--- a/libs/backroad-components/src/lib/components/markdown.tsx
+++ b/libs/backroad-components/src/lib/components/markdown.tsx
@@ -12,6 +12,7 @@ export const Markdown: BackroadComponentRenderer<'markdown'> = (props) => {
           a: (props) => {
             return <Link to={props.href || '/'}>{props.children}</Link>;
           },
+          pre: (props) => <pre className="overflow-x-auto" {...props} />,
         }}
       >
         {props.args.body.toString()}

--- a/libs/backroad-components/src/lib/containers/columns.tsx
+++ b/libs/backroad-components/src/lib/containers/columns.tsx
@@ -13,7 +13,11 @@ export const Columns: BackroadContainerRenderer<'columns'> = (props) => {
       }}
     >
       {props.children.map((child) => {
-        return <TreeRender tree={child} key={child.path} />;
+        return (
+          <div className="min-w-0" key={child.path}>
+            <TreeRender tree={child} />
+          </div>
+        );
       })}
     </div>
   );

--- a/libs/backroad-components/src/lib/socket/value-setters.ts
+++ b/libs/backroad-components/src/lib/socket/value-setters.ts
@@ -9,6 +9,7 @@ export const setBackroadValue = (props: { id: string; value: unknown }) => {
       {
         id: props.id,
         value: superjson.stringify(props.value),
+        pathname: window.location.pathname,
       },
       () => {
         resolve();
@@ -22,9 +23,13 @@ export const setRunUnsetBackroadValue = (
 ) => {
   return new Promise<void>((resolve) => {
     setBackroadValue(props).then(() => {
-      socket.emit('unset_value', { id: props.id }, () => {
-        resolve();
-      });
+      socket.emit(
+        'unset_value',
+        { id: props.id, pathname: window.location.pathname },
+        () => {
+          resolve();
+        }
+      );
     });
   });
 };

--- a/libs/backroad-core/src/lib/events.ts
+++ b/libs/backroad-core/src/lib/events.ts
@@ -58,6 +58,10 @@ export type BackroadEventsMapping = {
     args: {
       id: string;
       value: string;
+      // The path the client is on when this run is triggered. Every
+      // run-triggering event carries it so the server derives currentPath
+      // purely from the request — no persisted/assumed state.
+      pathname: string;
     };
     response?: void;
   };
@@ -84,7 +88,7 @@ export type BackroadEventsMapping = {
     response?: never;
   };
   unset_value: {
-    args: { id: string };
+    args: { id: string; pathname: string };
     response?: void;
   };
   backroad_config: {

--- a/libs/backroad-frontend/src/app/app.tsx
+++ b/libs/backroad-frontend/src/app/app.tsx
@@ -5,9 +5,9 @@ import {
 } from '@backroad/core';
 import { TreeRender, socket } from 'backroad-components';
 import { set } from 'lodash';
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import ReactGA from 'react-ga4';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import superjson from 'superjson';
 import { Navbar } from './layout/navbar';
 import useBackroadConfig from './hooks/useBackroadConfig';
@@ -53,6 +53,21 @@ export function App() {
       socket.off('disconnect', onDisconnect);
     };
   }, []);
+
+  // In-app navigation (React Router <Link>) changes the URL client-side
+  // without a socket round-trip, so the server would never learn the new
+  // path. Re-emit run_script on pathname change so the executor re-runs with
+  // the correct currentPath. Skip the initial mount — the connect effect
+  // already fires the first run — to avoid a double run on load.
+  const location = useLocation();
+  const didMountRef = useRef(false);
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    socket.emit('run_script', { pathname: location.pathname }, () => undefined);
+  }, [location.pathname]);
 
   const config = useBackroadConfig();
   useEffect(() => {

--- a/libs/backroad-frontend/src/app/app.tsx
+++ b/libs/backroad-frontend/src/app/app.tsx
@@ -19,17 +19,36 @@ import type { ThemeName } from './theme/themes';
 // the /signin/* routes, so React.lazy keeps them out of every other page
 // view.
 const AuthRoute = lazy(() => import('./auth/signin'));
+
+// Asks the server to (re)run the script for the given path. The server has no
+// path state of its own, so the run is what carries currentPath to it.
+//
+// Two things must trigger a run, and both reduce to "we're connected and the
+// path is known":
+//   - (re)connect — `connected` flips true (initial load, or after a drop)
+//   - in-app navigation — React Router <Link> changes the URL client-side with
+//     no socket round-trip, so only `pathname` changes
+//
+// Gating on `connected` (which starts false) means mounting alone never emits,
+// so there's no duplicate initial run to guard against.
+function useRunScript(connected: boolean, pathname: string) {
+  useEffect(() => {
+    if (!connected) return;
+    socket.emit('run_script', { pathname }, () => undefined);
+  }, [connected, pathname]);
+}
+
 export function App() {
   const [connected, setConnected] = useState(false);
   const [treeStruct, setTreeStruct] = useState<BackroadContainer<'base', true>>(
     getInitialTreeStructure()
   );
+  // Keep `connected` in sync with the socket (drives the Navbar indicator).
+  // `socket` is a module-level singleton — it may already be connected by the
+  // time this mounts (especially with the larger better-auth-ui bundle), so
+  // seed from `socket.connected` to avoid sitting on "Disconnected" forever
+  // after a missed `connect` event.
   useEffect(() => {
-    // `socket` is a module-level singleton — connection may already be
-    // established by the time this component mounts (especially with the
-    // larger bundle now that better-auth-ui is included). Seed initial
-    // state from `socket.connected` so we don't sit forever on
-    // "Disconnected" after a missed `connect` event.
     if (socket.connected) setConnected(true);
     const onConnect = () => setConnected(true);
     const onDisconnect = () => setConnected(false);
@@ -41,18 +60,8 @@ export function App() {
     };
   }, []);
 
-  // A run is triggered whenever we're connected and on a known path. This
-  // single rule covers both cases that need an initial/refresh run:
-  //   - (re)connect: `connected` flips true → emit
-  //   - in-app navigation: React Router <Link> changes the URL client-side
-  //     with no socket round-trip, so `location.pathname` changes → emit
-  // Gating on `connected` (which starts false) means mount alone never emits —
-  // there's no duplicate initial run to guard against.
   const location = useLocation();
-  useEffect(() => {
-    if (!connected) return;
-    socket.emit('run_script', { pathname: location.pathname }, () => undefined);
-  }, [connected, location.pathname]);
+  useRunScript(connected, location.pathname);
 
   const config = useBackroadConfig();
   useEffect(() => {

--- a/libs/backroad-frontend/src/app/app.tsx
+++ b/libs/backroad-frontend/src/app/app.tsx
@@ -5,7 +5,7 @@ import {
 } from '@backroad/core';
 import { TreeRender, socket } from 'backroad-components';
 import { set } from 'lodash';
-import { lazy, Suspense, useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import ReactGA from 'react-ga4';
 import { Route, Routes, useLocation } from 'react-router-dom';
 import superjson from 'superjson';
@@ -30,21 +30,8 @@ export function App() {
     // larger bundle now that better-auth-ui is included). Seed initial
     // state from `socket.connected` so we don't sit forever on
     // "Disconnected" after a missed `connect` event.
-    if (socket.connected) {
-      setConnected(true);
-      socket.emit(
-        'run_script',
-        { pathname: window.location.pathname },
-        () => undefined
-      );
-    }
-    const onConnect = () => {
-      setConnected(true);
-      console.log('sending run script request');
-      socket.emit('run_script', { pathname: window.location.pathname }, () => {
-        console.log('ran script');
-      });
-    };
+    if (socket.connected) setConnected(true);
+    const onConnect = () => setConnected(true);
     const onDisconnect = () => setConnected(false);
     socket.on('connect', onConnect);
     socket.on('disconnect', onDisconnect);
@@ -54,20 +41,18 @@ export function App() {
     };
   }, []);
 
-  // In-app navigation (React Router <Link>) changes the URL client-side
-  // without a socket round-trip, so the server would never learn the new
-  // path. Re-emit run_script on pathname change so the executor re-runs with
-  // the correct currentPath. Skip the initial mount — the connect effect
-  // already fires the first run — to avoid a double run on load.
+  // A run is triggered whenever we're connected and on a known path. This
+  // single rule covers both cases that need an initial/refresh run:
+  //   - (re)connect: `connected` flips true → emit
+  //   - in-app navigation: React Router <Link> changes the URL client-side
+  //     with no socket round-trip, so `location.pathname` changes → emit
+  // Gating on `connected` (which starts false) means mount alone never emits —
+  // there's no duplicate initial run to guard against.
   const location = useLocation();
-  const didMountRef = useRef(false);
   useEffect(() => {
-    if (!didMountRef.current) {
-      didMountRef.current = true;
-      return;
-    }
+    if (!connected) return;
     socket.emit('run_script', { pathname: location.pathname }, () => undefined);
-  }, [location.pathname]);
+  }, [connected, location.pathname]);
 
   const config = useBackroadConfig();
   useEffect(() => {

--- a/libs/backroad-frontend/src/stories/Markdown.stories.tsx
+++ b/libs/backroad-frontend/src/stories/Markdown.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { backroadClientComponents } from 'backroad-components';
+
+const Markdown = backroadClientComponents.markdown;
+
+const themes = [
+  'default',
+  'claude',
+  'twitter',
+  'supabase',
+  'amethyst-haze',
+] as const;
+type Theme = (typeof themes)[number];
+
+const SAMPLE = `# Markdown
+
+Prose pairs with a themed code panel. Inline \`code\` is a chip, and fenced
+blocks track the active palette + mode instead of a fixed dark slate.
+
+\`\`\`sh
+echo hi
+\`\`\`
+
+\`\`\`
+some output
+\`\`\`
+`;
+
+// A single very long line inside a fenced block + a wide inline JSON blob —
+// the kind of content that, without `overflow-x-auto` on <pre>, would blow out
+// its container instead of scrolling internally.
+const LONG_CODE = `# Long code overflow
+
+A fenced block with one very long line should scroll horizontally **inside**
+the panel — it must not stretch the card (or, in a columns layout, the column).
+
+\`\`\`sh
+cat /etc/os-release 2>/dev/null || uname -a && echo "PRETTY_NAME=Ubuntu plucky; VERSION_CODENAME=plucky; LOGO=ubuntu-logo; details={command: 'cat /etc/os-release', exitCode: 0, durationMs: 272}"
+\`\`\`
+
+\`\`\`
+{"id":"backroad-6e6e5c00-aea2-4028-a5d9-41324bd60da6","tool":"bash","args":{"command":"cat /etc/os-release 2>/dev/null || uname -a"},"result":{"stdout":"PRETTY_NAME=\\"Ubuntu plucky\\"\\nVERSION_CODENAME=plucky\\nLOGO=ubuntu-logo","details":{"command":"cat /etc/os-release 2>/dev/null || uname -a","exitCode":0}}}
+\`\`\`
+`;
+
+const MarkdownCard = ({
+  theme,
+  body,
+  width = 'w-[32rem]',
+}: {
+  theme?: Theme;
+  body: string;
+  width?: string;
+}) => (
+  <div
+    data-theme={theme ?? 'default'}
+    className={`${width} rounded-3xl border border-border bg-card p-6 text-card-foreground shadow-sm`}
+  >
+    <Markdown
+      path="story"
+      id="story"
+      type="markdown"
+      value={null}
+      args={{ body }}
+    />
+  </div>
+);
+
+const meta: Meta<typeof MarkdownCard> = {
+  title: 'AI Elements/Markdown',
+  component: MarkdownCard,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    theme: { control: 'select', options: themes },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof MarkdownCard>;
+
+export const Default: Story = {
+  args: { theme: 'default', body: SAMPLE },
+};
+
+export const Claude: Story = {
+  args: { theme: 'claude', body: SAMPLE },
+};
+
+// Long code lines scroll horizontally inside the panel instead of widening
+// the card. Rendered in a deliberately narrow container to make the internal
+// scrollbar obvious.
+export const LongCode: Story = {
+  render: () => <MarkdownCard body={LONG_CODE} width="w-[24rem]" />,
+};
+
+// The same long-code markdown placed inside a 2-column grid (mirroring the
+// `columns` container) — proves one wide column can't disrupt the column
+// distribution; it scrolls within its own min-w-0 cell.
+export const LongCodeInColumns: Story = {
+  render: () => (
+    <div className="grid w-[40rem] grid-cols-2 gap-4">
+      <div className="min-w-0">
+        <MarkdownCard body={LONG_CODE} width="w-full" />
+      </div>
+      <div className="min-w-0">
+        <MarkdownCard body={SAMPLE} width="w-full" />
+      </div>
+    </div>
+  ),
+};
+
+export const AllThemes: Story = {
+  render: () => (
+    <div style={{ padding: '2rem' }} className="space-y-8">
+      {/* Every theme is rendered in BOTH light and dark so each mode's code
+          panel contrast is independently scanned — a code block that goes dark
+          in light mode (the bug this fixes) is caught here. */}
+      {themes.flatMap((theme) =>
+        (['light', 'dark'] as const).map((mode) => (
+          <div
+            key={`${theme}-${mode}`}
+            data-theme={theme}
+            className={`space-y-4 rounded-lg bg-background p-4 text-foreground${
+              mode === 'dark' ? ' dark' : ''
+            }`}
+          >
+            <h4 className="text-sm font-medium text-foreground">
+              {theme} ({mode})
+            </h4>
+            <MarkdownCard body={SAMPLE} />
+          </div>
+        ))
+      )}
+    </div>
+  ),
+};

--- a/libs/backroad-frontend/src/stories/Markdown.stories.tsx
+++ b/libs/backroad-frontend/src/stories/Markdown.stories.tsx
@@ -123,9 +123,12 @@ export const AllThemes: Story = {
               mode === 'dark' ? ' dark' : ''
             }`}
           >
-            <h4 className="text-sm font-medium text-foreground">
+            {/* Decorative caption, not document structure — a real heading
+                here would sit before the markdown's <h1> and trip axe's
+                heading-order rule. */}
+            <div className="text-sm font-medium text-foreground">
               {theme} ({mode})
-            </h4>
+            </div>
             <MarkdownCard body={SAMPLE} />
           </div>
         ))

--- a/libs/backroad-frontend/src/styles.css
+++ b/libs/backroad-frontend/src/styles.css
@@ -444,7 +444,9 @@
 
 @layer utilities {
   @keyframes typing-dot {
-    0%, 60%, 100% {
+    0%,
+    60%,
+    100% {
       transform: translateY(0);
       opacity: 0.4;
     }
@@ -455,7 +457,9 @@
   }
 
   @keyframes typing-bar {
-    0%, 60%, 100% {
+    0%,
+    60%,
+    100% {
       transform: scaleY(0.4);
       opacity: 0.4;
     }
@@ -499,11 +503,47 @@
     --tw-prose-captions: currentColor;
     --tw-prose-kbd: currentColor;
     --tw-prose-code: currentColor;
-    --tw-prose-pre-code: currentColor;
+    /* Code is the one exception to currentColor inheritance: a fenced block is
+       its own surface, so it can't borrow the container's text colour (light
+       text on a primary bubble would be unreadable on the neutral code panel).
+       Pin its surface/text to theme tokens instead so it tracks the active
+       palette + mode — light panel in light mode, dark in dark — rather than
+       Tailwind Typography's hardcoded dark-slate `--tw-prose-pre-bg`. */
+    --tw-prose-pre-bg: var(--muted);
+    --tw-prose-pre-code: var(--foreground);
     --tw-prose-hr: color-mix(in oklch, currentColor 20%, transparent);
-    --tw-prose-quote-borders: color-mix(in oklch, currentColor 30%, transparent);
+    --tw-prose-quote-borders: color-mix(
+      in oklch,
+      currentColor 30%,
+      transparent
+    );
     --tw-prose-th-borders: color-mix(in oklch, currentColor 25%, transparent);
     --tw-prose-td-borders: color-mix(in oklch, currentColor 15%, transparent);
+  }
+
+  /* Give fenced code blocks a border so the neutral `--muted` panel reads as a
+     distinct surface against same-tone cards. */
+  .prose-inherit-color :where(pre) {
+    border: 1px solid var(--border);
+  }
+
+  /* Inline `code` becomes a themed chip (surface + border + text) that pairs
+     with the active palette, instead of inheriting the container's text colour
+     with no background. Excludes code inside `pre`, which keeps the block
+     styling above. */
+  .prose-inherit-color :where(code):not(:where(pre code)) {
+    background-color: var(--muted);
+    color: var(--foreground);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.125em 0.375em;
+    font-weight: 500;
+  }
+  /* Drop Tailwind Typography's literal backtick pseudo-elements — the chip
+     already signals "code". */
+  .prose-inherit-color :where(code):not(:where(pre code))::before,
+  .prose-inherit-color :where(code):not(:where(pre code))::after {
+    content: none;
   }
 }
 

--- a/libs/backroad/src/lib/runner/index.ts
+++ b/libs/backroad/src/lib/runner/index.ts
@@ -62,13 +62,15 @@ export const run = async (
       }
     }
 
-    const runExecutor = async (pathname = '/') => {
+    // currentPath is derived purely from the triggering request — every
+    // run-triggering event (run_script, set_value, unset_value) carries the
+    // client's pathname, so the server holds no path state and assumes no
+    // default. No run is ever server-initiated.
+    const runExecutor = async (currentPath: string) => {
       socket.emit('running', true, () => undefined);
       try {
         backroadSession.resetTree();
-        await executor(backroadSession.mainPageNodeManager, {
-          currentPath: pathname,
-        });
+        await executor(backroadSession.mainPageNodeManager, { currentPath });
       } finally {
         socket.emit('running', false, () => undefined);
       }

--- a/libs/backroad/src/lib/server/server-socket-event-handlers/set_value.ts
+++ b/libs/backroad/src/lib/server/server-socket-event-handlers/set_value.ts
@@ -2,7 +2,7 @@ import superjson from 'superjson';
 import { IServerSocketEventHandler } from './types';
 export const setValue: IServerSocketEventHandler<
   'set_value',
-  () => Promise<void>
+  (pathname: string) => Promise<void>
 > = (socket, backroadSession, runExecutor) => async (props, callback) => {
   // console.log(
   //   'setting value before triggering rerun, new value for ',
@@ -11,13 +11,7 @@ export const setValue: IServerSocketEventHandler<
   //   props.value
   // );
   backroadSession.setValue(props.id, superjson.parse(props.value));
-  // if (props.triggerRerun === true || props.triggerRerun === undefined) {
-  // console.log('triggering rerun');
-  // backroadSession.setRunnerProcess({
-  //   scriptPath: context.scriptPath,
-  //   serverPort: context.serverPort,
-  // });
-  await runExecutor();
+  await runExecutor(props.pathname);
   callback();
   // socket.emit('running', null, () => {
   //   console.log('running event emitted');

--- a/libs/backroad/src/lib/server/server-socket-event-handlers/unset_value.ts
+++ b/libs/backroad/src/lib/server/server-socket-event-handlers/unset_value.ts
@@ -1,19 +1,9 @@
 import { IServerSocketEventHandler } from './types';
 export const unsetValue: IServerSocketEventHandler<
   'unset_value',
-  () => Promise<void>
+  (pathname: string) => Promise<void>
 > = (socket, backroadSession, runExecutor) => async (props, callback) => {
   backroadSession.unsetValue(props.id);
-  // if (props.triggerRerun === true || props.triggerRerun === undefined) {
-  // console.log('triggering rerun');
-  // backroadSession.setRunnerProcess({
-  //   scriptPath: context.scriptPath,
-  //   serverPort: context.serverPort,
-  // });
-  await runExecutor();
+  await runExecutor(props.pathname);
   callback();
-  // socket.emit('running', null, () => {
-  //   console.log('running event emitted');
-  // });
-  // }
 };


### PR DESCRIPTION
## Summary

Makes the sidebar truly page-agnostic, exposes the active route to the executor, and fixes layout bugs where wide content could disrupt column distribution.

### Sidebar: shared across all pages
- `br.sidebar()` now attaches to the **root** node (like `br.page()`) instead of the home-page subtree, so it stays mounted across every route — previously it unmounted on navigation because it lived inside the `/` page's tree.
- `app.tsx` renders non-page root children (the sidebar) **outside** `<Routes>` so they persist regardless of the matched route.
- Sidebar auto-closes on navigation (`useLocation` effect) so the backdrop overlay doesn't linger after clicking a nav link.
- Fixed transparent sidebar background: `bg-base-200` (leftover daisyUI) → `bg-card` (shadcn token).

### `currentPath`: per-run route context
- The executor now receives a second argument: `run((br, { currentPath }) => …)`, letting apps conditionally populate the sidebar (or anything) based on the active route.
- The client sends `pathname` with `run_script`; the server threads it through `runExecutor` as a per-connection value (not stored on `BackroadSession`).
- No separate `navigate` event — folding the path into the existing run trigger avoids a redundant second run and the race window it created.

### Guardrail
- `br.page({ path: '/' })` now throws — `/` is what the root `br` object already represents.

### Layout: contain wide content
- `columns`: each grid cell wrapped in `min-w-0` so `fr` columns clamp to their fraction regardless of child width.
- `markdown`: fenced `<pre>` gets `overflow-x-auto` so long code lines scroll internally instead of widening the column.
- Themed fenced code panels + inline `code` chips that track the active palette/mode.
- Widened `columns` gutter (`gap-1` → `gap-6`) so the separation is visible.

### Docs & tests
- New "Conditional content per route" section in the sidebar docs + `currentPath` note in getting-started.
- Demo `columns` page rebuilt to make the gutter obvious (stat cards + ratio layout).
- E2E specs (`e2e/sidebar.spec.ts`) covering sidebar persistence across in-app navigation and per-path differentiation via `currentPath`.
- Storybook `LongCode` / `LongCodeInColumns` stories demonstrating overflow containment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)