### PR TITLE
feat(table): restyle + gated virtualization, stories, tests

### DIFF
--- a/libs/backroad-components/package.json
+++ b/libs/backroad-components/package.json
@@ -10,6 +10,7 @@
     "@backroad/core": "workspace:*",
     "@heroicons/react": "^2.0.18",
     "@tanstack/react-table": "^8.10.6",
+    "@tanstack/react-virtual": "^3.14.2",
     "backroad-ui": "workspace:*",
     "chart.js": "^4.4.0",
     "chartjs-plugin-autocolors": "^0.2.2",

--- a/libs/backroad-components/src/lib/components/index.tsx
+++ b/libs/backroad-components/src/lib/components/index.tsx
@@ -1,20 +1,15 @@
 import { BackroadComponent, InbuiltComponentTypes } from '@backroad/core';
-import { BarChart } from './bar_chart';
+import { lazy } from 'react';
 import { Button } from './button';
 import { ChatInput } from './chat_input';
-import { DoughnutChart } from './doughnut_chart';
 import { Image } from './image';
 import { Iframe } from './iframe';
 import { Json } from './json';
-import { LineChart } from './line_chart';
 import { Link } from './link';
 import { LinkGroup } from './link_group';
 import { Markdown } from './markdown';
 import { Multiselect } from './multiselect';
 import { NumberInput } from './number_input';
-import { PieChart } from './pie_chart';
-import { RadarChart } from './radar_chart';
-import { ScatterChart } from './scatter_chart';
 import { Select } from './select';
 import { Stats } from './stats';
 import { Table } from './table';
@@ -27,6 +22,30 @@ import { FileUpload } from './file_upload';
 import { TextInput } from './text_input';
 import { Video } from './video';
 import { LoadingSpinner } from './loading_spinner';
+
+// Charts are lazy-loaded so chart.js + react-chartjs-2 (the heaviest dependency
+// in this lib) ship in their own chunk instead of the main bundle — they're
+// only fetched once a chart actually renders. They all share one chunk because
+// they import the same chart.js core. TreeRender wraps every renderer in a
+// <Suspense> boundary, so the lazy load is transparent to callers.
+const LineChart = lazy(() =>
+  import('./line_chart').then((m) => ({ default: m.LineChart }))
+);
+const BarChart = lazy(() =>
+  import('./bar_chart').then((m) => ({ default: m.BarChart }))
+);
+const PieChart = lazy(() =>
+  import('./pie_chart').then((m) => ({ default: m.PieChart }))
+);
+const DoughnutChart = lazy(() =>
+  import('./doughnut_chart').then((m) => ({ default: m.DoughnutChart }))
+);
+const RadarChart = lazy(() =>
+  import('./radar_chart').then((m) => ({ default: m.RadarChart }))
+);
+const ScatterChart = lazy(() =>
+  import('./scatter_chart').then((m) => ({ default: m.ScatterChart }))
+);
 
 export const backroadClientComponents: {
   [key in InbuiltComponentTypes]: (
@@ -44,12 +63,12 @@ export const backroadClientComponents: {
 
   title: Title,
 
-  line_chart: LineChart,
-  bar_chart: BarChart,
-  pie_chart: PieChart,
-  doughnut_chart: DoughnutChart,
-  radar_chart: RadarChart,
-  scatter_chart: ScatterChart,
+  line_chart: (props) => <LineChart {...props} />,
+  bar_chart: (props) => <BarChart {...props} />,
+  pie_chart: (props) => <PieChart {...props} />,
+  doughnut_chart: (props) => <DoughnutChart {...props} />,
+  radar_chart: (props) => <RadarChart {...props} />,
+  scatter_chart: (props) => <ScatterChart {...props} />,
 
   chat_input: ChatInput,
 

--- a/libs/backroad-components/src/lib/components/table.tsx
+++ b/libs/backroad-components/src/lib/components/table.tsx
@@ -4,7 +4,21 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { useRef } from 'react';
 import { BackroadComponentRenderer } from '../types/components';
+
+// Past this many rows we stop rendering every <tr> and switch to a fixed-height
+// scroll viewport that only mounts the visible window (plus overscan). Smaller
+// tables render naturally so their height tracks content and the page scrolls
+// as one — no nested scrollbar, no sticky header.
+const VIRTUALIZE_THRESHOLD = 100;
+// px estimate for a row (py-2.5 + text-sm line). Only a seed — measureElement
+// corrects it from the real DOM, so variable-height rows still scroll cleanly.
+const ESTIMATED_ROW_HEIGHT = 41;
+
+const HEADER_CELL_CLASS =
+  'whitespace-nowrap px-4 py-2.5 text-left align-middle font-medium text-muted-foreground';
 
 export const Table: BackroadComponentRenderer<'table'> = (props) => {
   const columnsHelper = createColumnHelper<any>();
@@ -15,14 +29,62 @@ export const Table: BackroadComponentRenderer<'table'> = (props) => {
     }),
     getCoreRowModel: getCoreRowModel(),
   });
+
+  const rows = table.getRowModel().rows;
+  const columnCount = table.getAllLeafColumns().length;
+  const virtualize = rows.length > VIRTUALIZE_THRESHOLD;
+  const hasFooter = table
+    .getAllColumns()
+    .some((column) => column.columnDef.footer !== undefined);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    overscan: 12,
+    enabled: virtualize,
+  });
+
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const paddingTop = virtualRows.length > 0 ? virtualRows[0].start : 0;
+  const paddingBottom =
+    virtualRows.length > 0
+      ? rowVirtualizer.getTotalSize() - virtualRows[virtualRows.length - 1].end
+      : 0;
+
+  const renderRow = (row: (typeof rows)[number], virtualIndex?: number) => (
+    <tr
+      key={row.id}
+      data-index={virtualIndex}
+      ref={virtualize ? rowVirtualizer.measureElement : undefined}
+      className="border-b border-border transition-colors hover:bg-muted/50"
+    >
+      {row.getVisibleCells().map((cell) => (
+        <td key={cell.id} className="px-4 py-2.5 align-middle">
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </td>
+      ))}
+    </tr>
+  );
+
   return (
-    <div>
-      <table className="table">
-        <thead>
+    <div
+      ref={scrollRef}
+      className={`w-full rounded-lg border border-border bg-card text-card-foreground shadow-sm ${
+        virtualize ? 'max-h-[70vh] overflow-auto' : 'overflow-x-auto'
+      }`}
+    >
+      <table className="w-full border-collapse text-sm">
+        <thead
+          className={`bg-muted text-muted-foreground ${
+            virtualize ? 'sticky top-0 z-10' : ''
+          }`}
+        >
           {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id}>
+            <tr key={headerGroup.id} className="border-b border-border">
               {headerGroup.headers.map((header) => (
-                <th key={header.id}>
+                <th key={header.id} className={HEADER_CELL_CLASS}>
                   {header.isPlaceholder
                     ? null
                     : flexRender(
@@ -35,32 +97,48 @@ export const Table: BackroadComponentRenderer<'table'> = (props) => {
           ))}
         </thead>
         <tbody>
-          {table.getRowModel().rows.map((row) => (
-            <tr key={row.id}>
-              {row.getVisibleCells().map((cell) => (
-                <td key={cell.id}>
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              ))}
-            </tr>
-          ))}
+          {virtualize ? (
+            <>
+              {paddingTop > 0 && (
+                <tr aria-hidden="true">
+                  <td colSpan={columnCount} style={{ height: paddingTop }} />
+                </tr>
+              )}
+              {virtualRows.map((virtualRow) =>
+                renderRow(rows[virtualRow.index], virtualRow.index)
+              )}
+              {paddingBottom > 0 && (
+                <tr aria-hidden="true">
+                  <td colSpan={columnCount} style={{ height: paddingBottom }} />
+                </tr>
+              )}
+            </>
+          ) : (
+            rows.map((row) => renderRow(row))
+          )}
         </tbody>
-        <tfoot>
-          {table.getFooterGroups().map((footerGroup) => (
-            <tr key={footerGroup.id}>
-              {footerGroup.headers.map((header) => (
-                <th key={header.id}>
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(
-                        header.column.columnDef.footer,
-                        header.getContext()
-                      )}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </tfoot>
+        {hasFooter && (
+          <tfoot
+            className={`border-t border-border bg-muted text-muted-foreground ${
+              virtualize ? 'sticky bottom-0 z-10' : ''
+            }`}
+          >
+            {table.getFooterGroups().map((footerGroup) => (
+              <tr key={footerGroup.id}>
+                {footerGroup.headers.map((header) => (
+                  <th key={header.id} className={HEADER_CELL_CLASS}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.footer,
+                          header.getContext()
+                        )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </tfoot>
+        )}
       </table>
     </div>
   );

--- a/libs/backroad-components/src/lib/components/table.tsx
+++ b/libs/backroad-components/src/lib/components/table.tsx
@@ -17,8 +17,10 @@ const VIRTUALIZE_THRESHOLD = 100;
 // corrects it from the real DOM, so variable-height rows still scroll cleanly.
 const ESTIMATED_ROW_HEIGHT = 41;
 
+// text-foreground (not muted) so header/footer text clears WCAG AA contrast on
+// the bg-muted header strip — muted-on-muted fails the a11y gate.
 const HEADER_CELL_CLASS =
-  'whitespace-nowrap px-4 py-2.5 text-left align-middle font-medium text-muted-foreground';
+  'whitespace-nowrap px-4 py-2.5 text-left align-middle font-medium text-foreground';
 
 export const Table: BackroadComponentRenderer<'table'> = (props) => {
   const columnsHelper = createColumnHelper<any>();
@@ -69,15 +71,22 @@ export const Table: BackroadComponentRenderer<'table'> = (props) => {
   );
 
   return (
+    // tabIndex makes the scroll container keyboard-reachable so it can be
+    // scrolled without a mouse (axe scrollable-region-focusable).
+    // jsx-a11y/no-noninteractive-tabindex flags this, but the two rules
+    // directly conflict for scrollable regions — axe wins, the region needs
+    // to take focus.
     <div
       ref={scrollRef}
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex={0}
       className={`w-full rounded-lg border border-border bg-card text-card-foreground shadow-sm ${
         virtualize ? 'max-h-[70vh] overflow-auto' : 'overflow-x-auto'
       }`}
     >
       <table className="w-full border-collapse text-sm">
         <thead
-          className={`bg-muted text-muted-foreground ${
+          className={`bg-muted text-foreground ${
             virtualize ? 'sticky top-0 z-10' : ''
           }`}
         >
@@ -119,7 +128,7 @@ export const Table: BackroadComponentRenderer<'table'> = (props) => {
         </tbody>
         {hasFooter && (
           <tfoot
-            className={`border-t border-border bg-muted text-muted-foreground ${
+            className={`border-t border-border bg-muted text-foreground ${
               virtualize ? 'sticky bottom-0 z-10' : ''
             }`}
           >

--- a/libs/backroad-components/src/lib/tree.tsx
+++ b/libs/backroad-components/src/lib/tree.tsx
@@ -1,12 +1,18 @@
 import { BackroadNode, isBackroadComponent } from '@backroad/core';
+import { Suspense } from 'react';
 import { backroadClientComponents } from './components';
 import { backroadClientContainers } from './containers';
 
 export const TreeRender = (props: { tree: BackroadNode }) => {
   if (isBackroadComponent(props.tree, true)) {
     const ComponentRenderer = backroadClientComponents[props.tree.type];
-    // @ts-expect-error there are sufficient checks to ensure this is correct
-    return <ComponentRenderer {...props.tree} key={props.tree.value} />;
+    // Suspense boundary for lazy renderers (e.g. `table`); inert for the rest.
+    return (
+      <Suspense fallback={null}>
+        {/* @ts-expect-error there are sufficient checks to ensure this is correct */}
+        <ComponentRenderer {...props.tree} key={props.tree.value} />
+      </Suspense>
+    );
   } else {
     // @ts-expect-error there are sufficient checks to ensure this is correct
     const ContainerRenderer = backroadClientContainers[props.tree.type];

--- a/libs/backroad-frontend/src/stories/Table.stories.tsx
+++ b/libs/backroad-frontend/src/stories/Table.stories.tsx
@@ -103,10 +103,10 @@ export const WithFooter: Story = {
 };
 
 // --- Stress tests -----------------------------------------------------------
-// These exercise the layout limits. NOTE: the renderer has no virtualization or
-// pagination — it maps every row/column straight into the DOM — so these also
-// surface raw render cost. The `overflow-x-auto` wrapper keeps wide tables from
-// blowing out the page; tall tables render all rows.
+// These exercise the layout limits. Wide tables stay on the `overflow-x-auto`
+// wrapper so they scroll horizontally instead of blowing out the page. Tall
+// tables cross the virtualization threshold and switch to a bounded scroll
+// viewport that only mounts the visible window of rows.
 
 const WIDE_COLUMN_COUNT = 40;
 const WIDE_COLUMNS: Columns = Object.fromEntries(
@@ -141,8 +141,8 @@ const LONG_DATA: Row[] = Array.from({ length: LONG_ROW_COUNT }, (_, i) => ({
   started: `2026-06-15T${String(i % 24).padStart(2, '0')}:00:00.000Z`,
 }));
 
-/** 2,000 rows — there is NO virtualization, so all 2,000 rows mount as real DOM
- * nodes. Use this to feel the render/scroll cost that windowing would remove. */
+/** 2,000 rows — past the virtualization threshold, so only the visible window
+ * (plus overscan) mounts as DOM nodes inside a bounded scroll viewport. */
 export const LongTable: Story = {
   render: () => <Table {...table(SANDBOX_COLUMNS, LONG_DATA)} />,
 };

--- a/libs/backroad-frontend/src/stories/Table.stories.tsx
+++ b/libs/backroad-frontend/src/stories/Table.stories.tsx
@@ -1,0 +1,156 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { backroadClientComponents } from 'backroad-components';
+import { ThemeMatrix } from './theme-matrix';
+
+// The real `table` renderer — drives `@tanstack/react-table` under the hood.
+// `columns` maps each data key to a column def (`header`, `cell`, `footer`, …);
+// `data` is the row array.
+const Table = backroadClientComponents.table;
+type Columns = Parameters<typeof Table>[0]['args']['columns'];
+type Row = Record<string, unknown>;
+const table = (columns: Columns, data: Row[]) => ({
+  path: 'story',
+  id: 'story',
+  type: 'table' as const,
+  value: null,
+  args: { columns, data },
+});
+
+const meta: Meta<typeof Table> = {
+  title: 'Components/Table',
+  component: Table,
+  parameters: { layout: 'padded' },
+};
+export default meta;
+type Story = StoryObj<typeof Table>;
+
+const SANDBOX_COLUMNS: Columns = {
+  id: { header: 'Sandbox' },
+  state: { header: 'State' },
+  session: { header: 'Session' },
+  vcpu: { header: 'vCPU' },
+  ram: { header: 'RAM (MiB)' },
+  started: { header: 'Started' },
+};
+
+const SANDBOX_DATA: Row[] = [
+  {
+    id: 'i90z7tggm5dvny1wib624',
+    state: 'running',
+    session: 'backroad-3e111f1b-e02e-4694-80e9-a89bae37d52f',
+    vcpu: 4,
+    ram: 8192,
+    started: '2026-06-15T15:39:55.003Z',
+  },
+  {
+    id: 'k21a8whqn4exrt7zca910',
+    state: 'paused',
+    session: 'backroad-9f02c3aa-1b77-4c0e-bb31-77c4e2901aa2',
+    vcpu: 2,
+    ram: 4096,
+    started: '2026-06-15T14:02:11.880Z',
+  },
+  {
+    id: 'p55m3dkce0wbxq2yhn183',
+    state: 'running',
+    session: 'backroad-12ab4f9e-77de-4a90-9c44-0e5b6d3f2c10',
+    vcpu: 8,
+    ram: 16384,
+    started: '2026-06-15T11:48:30.512Z',
+  },
+];
+
+/** Typical multi-column table with long ids that overflow horizontally. */
+export const Default: Story = {
+  render: () => <Table {...table(SANDBOX_COLUMNS, SANDBOX_DATA)} />,
+};
+
+/** A single row — header/row spacing without zebra context. */
+export const SingleRow: Story = {
+  render: () => <Table {...table(SANDBOX_COLUMNS, [SANDBOX_DATA[0]])} />,
+};
+
+/** No rows — header renders, body is empty. */
+export const Empty: Story = {
+  render: () => <Table {...table(SANDBOX_COLUMNS, [])} />,
+};
+
+// Footer totals precomputed from the data so the column defs stay plain values
+// (react-table also accepts a `(ctx) => …` footer, but a static value is enough
+// to exercise the otherwise-hidden `<tfoot>`).
+const REGION_DATA: Row[] = [
+  { region: 'us-east-1', running: 3, ram: 24576 },
+  { region: 'eu-west-1', running: 1, ram: 8192 },
+  { region: 'ap-south-1', running: 2, ram: 12288 },
+];
+const REGION_COLUMNS: Columns = {
+  region: { header: 'Region', footer: 'Total' },
+  running: {
+    header: 'Running',
+    footer: String(
+      REGION_DATA.reduce((sum, r) => sum + (r.running as number), 0)
+    ),
+  },
+  ram: {
+    header: 'RAM (MiB)',
+    footer: String(REGION_DATA.reduce((sum, r) => sum + (r.ram as number), 0)),
+  },
+};
+
+/** Columns with footers render the (otherwise hidden) `<tfoot>`. */
+export const WithFooter: Story = {
+  render: () => <Table {...table(REGION_COLUMNS, REGION_DATA)} />,
+};
+
+// --- Stress tests -----------------------------------------------------------
+// These exercise the layout limits. NOTE: the renderer has no virtualization or
+// pagination — it maps every row/column straight into the DOM — so these also
+// surface raw render cost. The `overflow-x-auto` wrapper keeps wide tables from
+// blowing out the page; tall tables render all rows.
+
+const WIDE_COLUMN_COUNT = 40;
+const WIDE_COLUMNS: Columns = Object.fromEntries(
+  Array.from({ length: WIDE_COLUMN_COUNT }, (_, c) => [
+    `col${c}`,
+    { header: `Column ${c + 1}` },
+  ])
+);
+const WIDE_DATA: Row[] = Array.from({ length: 12 }, (_, r) =>
+  Object.fromEntries(
+    Array.from({ length: WIDE_COLUMN_COUNT }, (_, c) => [
+      `col${c}`,
+      `r${r + 1}·c${c + 1}`,
+    ])
+  )
+);
+
+/** 40 columns — verifies the container scrolls horizontally instead of crushing
+ * cells or overflowing the page. */
+export const WideTable: Story = {
+  render: () => <Table {...table(WIDE_COLUMNS, WIDE_DATA)} />,
+};
+
+const LONG_ROW_COUNT = 2000;
+const STATES = ['running', 'paused', 'stopped'];
+const LONG_DATA: Row[] = Array.from({ length: LONG_ROW_COUNT }, (_, i) => ({
+  id: `sandbox-${String(i).padStart(5, '0')}`,
+  state: STATES[i % STATES.length],
+  session: `backroad-${String(i).padStart(8, '0')}-e02e-4694-80e9-a89bae37d52f`,
+  vcpu: (i % 8) + 1,
+  ram: ((i % 8) + 1) * 1024,
+  started: `2026-06-15T${String(i % 24).padStart(2, '0')}:00:00.000Z`,
+}));
+
+/** 2,000 rows — there is NO virtualization, so all 2,000 rows mount as real DOM
+ * nodes. Use this to feel the render/scroll cost that windowing would remove. */
+export const LongTable: Story = {
+  render: () => <Table {...table(SANDBOX_COLUMNS, LONG_DATA)} />,
+};
+
+export const AllThemes: Story = {
+  render: () => (
+    <ThemeMatrix>
+      <Table {...table(SANDBOX_COLUMNS, SANDBOX_DATA)} />
+    </ThemeMatrix>
+  ),
+};

--- a/libs/backroad-frontend/src/table.test.tsx
+++ b/libs/backroad-frontend/src/table.test.tsx
@@ -1,0 +1,198 @@
+import { render } from '@testing-library/react';
+import { backroadClientComponents } from 'backroad-components';
+
+// Test the real `table` renderer the backroad tree mounts (drives
+// @tanstack/react-table + @tanstack/react-virtual), so the tests track what
+// actually ships.
+const Table = backroadClientComponents.table;
+type Columns = Parameters<typeof Table>[0]['args']['columns'];
+type Row = Record<string, unknown>;
+const tableProps = (columns: Columns, data: Row[]) => ({
+  path: 'test',
+  id: 'test',
+  type: 'table' as const,
+  value: null,
+  args: { columns, data },
+});
+
+const COLUMNS: Columns = {
+  id: { header: 'Sandbox' },
+  state: { header: 'State' },
+};
+
+const makeRows = (n: number): Row[] =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `sandbox-${String(i).padStart(5, '0')}`,
+    state: i % 2 === 0 ? 'running' : 'paused',
+  }));
+
+// tbody rows excluding the aria-hidden spacer rows the virtualizer injects.
+const dataRows = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('tbody tr')).filter(
+    (tr) => tr.getAttribute('aria-hidden') !== 'true'
+  );
+
+describe('Table', () => {
+  it('renders column headers', () => {
+    const { getByText } = render(
+      <Table {...tableProps(COLUMNS, makeRows(3))} />
+    );
+    expect(getByText('Sandbox')).toBeTruthy();
+    expect(getByText('State')).toBeTruthy();
+  });
+
+  it('renders cell content for each row', () => {
+    const { getByText } = render(
+      <Table {...tableProps(COLUMNS, makeRows(3))} />
+    );
+    expect(getByText('sandbox-00000')).toBeTruthy();
+    expect(getByText('sandbox-00002')).toBeTruthy();
+  });
+
+  it('renders an empty body when there is no data', () => {
+    const { container } = render(<Table {...tableProps(COLUMNS, [])} />);
+    expect(dataRows(container)).toHaveLength(0);
+    // Header still present.
+    expect(container.querySelector('thead th')).toBeTruthy();
+  });
+
+  it('omits <tfoot> when no column defines a footer', () => {
+    const { container } = render(
+      <Table {...tableProps(COLUMNS, makeRows(3))} />
+    );
+    expect(container.querySelector('tfoot')).toBeNull();
+  });
+
+  it('renders <tfoot> when a column defines a footer', () => {
+    const withFooter: Columns = {
+      id: { header: 'Sandbox', footer: 'Total' },
+      state: { header: 'State' },
+    };
+    const { container, getByText } = render(
+      <Table {...tableProps(withFooter, makeRows(3))} />
+    );
+    expect(container.querySelector('tfoot')).toBeTruthy();
+    expect(getByText('Total')).toBeTruthy();
+  });
+
+  // The gate between "render every row" and "virtualize" is what we can assert
+  // deterministically. The actual windowed row count depends on real layout
+  // measurement, which jsdom doesn't provide (every rect is 0×0) — that's
+  // covered by the Storybook `LongTable` story / visual check, not here.
+  describe('virtualization gate', () => {
+    const wrapper = (container: HTMLElement) =>
+      container.firstElementChild as HTMLElement;
+    const thead = (container: HTMLElement) =>
+      container.querySelector('thead') as HTMLElement;
+
+    it('renders naturally at the threshold (no scroll viewport)', () => {
+      const { container } = render(
+        <Table {...tableProps(COLUMNS, makeRows(100))} />
+      );
+      // All rows present, no spacer rows.
+      expect(dataRows(container)).toHaveLength(100);
+      expect(
+        container.querySelectorAll('tbody tr[aria-hidden="true"]')
+      ).toHaveLength(0);
+      // Page-flow layout: horizontal overflow only, no bounded height, header
+      // not sticky.
+      expect(wrapper(container).className).toContain('overflow-x-auto');
+      expect(wrapper(container).className).not.toContain('max-h-');
+      expect(thead(container).className).not.toContain('sticky');
+    });
+
+    it('switches to a bounded scroll viewport past the threshold', () => {
+      const { container } = render(
+        <Table {...tableProps(COLUMNS, makeRows(101))} />
+      );
+      expect(wrapper(container).className).toContain('max-h-[70vh]');
+      expect(wrapper(container).className).toContain('overflow-auto');
+      // Sticky header so it survives scrolling the windowed rows.
+      expect(thead(container).className).toContain('sticky');
+    });
+  });
+
+  // jsdom has no layout engine, so @tanstack/react-virtual sees 0×0 for every
+  // element and renders an empty window. The virtualizer reads the viewport and
+  // row sizes from `offsetHeight` (synchronously — no ResizeObserver needed for
+  // the initial measure), so feeding realistic values lets us assert the actual
+  // windowing: that only a fraction of rows mount as DOM nodes.
+  describe('windowing (with mocked layout geometry)', () => {
+    const ROW_H = 40;
+    const VIEWPORT_H = 700;
+    let originalOffsetHeight: PropertyDescriptor | undefined;
+    let originalOffsetWidth: PropertyDescriptor | undefined;
+
+    beforeAll(() => {
+      originalOffsetHeight = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        'offsetHeight'
+      );
+      originalOffsetWidth = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        'offsetWidth'
+      );
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+        configurable: true,
+        get(this: HTMLElement) {
+          // Rows report a real height; the scroll viewport reports its height.
+          return this.tagName === 'TR' ? ROW_H : VIEWPORT_H;
+        },
+      });
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+        configurable: true,
+        get: () => 800,
+      });
+    });
+
+    afterAll(() => {
+      if (originalOffsetHeight) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          'offsetHeight',
+          originalOffsetHeight
+        );
+      }
+      if (originalOffsetWidth) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          'offsetWidth',
+          originalOffsetWidth
+        );
+      }
+    });
+
+    it('mounts only a small window of a 2,000-row table', () => {
+      const total = 2000;
+      const { container } = render(
+        <Table {...tableProps(COLUMNS, makeRows(total))} />
+      );
+      const rendered = dataRows(container).length;
+      // ~viewport/row + overscan worth of rows, nowhere near the full 2,000.
+      const maxExpected = Math.ceil(VIEWPORT_H / ROW_H) + 12 * 2 + 5;
+      expect(rendered).toBeGreaterThan(0);
+      expect(rendered).toBeLessThanOrEqual(maxExpected);
+    });
+
+    it('renders the rows at the top of the scroll offset, not the bottom', () => {
+      const { getByText, queryByText } = render(
+        <Table {...tableProps(COLUMNS, makeRows(2000))} />
+      );
+      // scrollTop is 0, so the first row is mounted and a far-down row is not.
+      expect(getByText('sandbox-00000')).toBeTruthy();
+      expect(queryByText('sandbox-01999')).toBeNull();
+    });
+
+    it('injects spacer rows to preserve total scroll height', () => {
+      const { container } = render(
+        <Table {...tableProps(COLUMNS, makeRows(2000))} />
+      );
+      // At scrollTop 0 there's no top spacer, but a bottom spacer holds the
+      // height of the ~1,960 un-mounted rows.
+      const spacers = container.querySelectorAll(
+        'tbody tr[aria-hidden="true"]'
+      );
+      expect(spacers.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/libs/backroad-frontend/src/table.test.tsx
+++ b/libs/backroad-frontend/src/table.test.tsx
@@ -75,10 +75,10 @@ describe('Table', () => {
     expect(getByText('Total')).toBeTruthy();
   });
 
-  // The gate between "render every row" and "virtualize" is what we can assert
-  // deterministically. The actual windowed row count depends on real layout
-  // measurement, which jsdom doesn't provide (every rect is 0×0) — that's
-  // covered by the Storybook `LongTable` story / visual check, not here.
+  // The gate between "render every row" and "virtualize" asserts deterministically
+  // (no layout needed). The actual windowed row count needs real measurements,
+  // which jsdom lacks (every rect is 0×0) — that's covered separately in the
+  // "windowing" block below by mocking element geometry.
   describe('virtualization gate', () => {
     const wrapper = (container: HTMLElement) =>
       container.firstElementChild as HTMLElement;

--- a/libs/backroad-frontend/src/test-setup.ts
+++ b/libs/backroad-frontend/src/test-setup.ts
@@ -14,3 +14,20 @@ if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
       dispatchEvent: () => false,
     } as MediaQueryList);
 }
+
+// jsdom doesn't implement ResizeObserver, which @tanstack/react-virtual (used
+// by the virtualized `table` component) constructs on mount. Provide a no-op
+// stub so virtualized components can render in tests.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {
+      return undefined;
+    }
+    unobserve() {
+      return undefined;
+    }
+    disconnect() {
+      return undefined;
+    }
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.10.6
         version: 8.21.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.2
+        version: 3.14.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       backroad-ui:
         specifier: workspace:*
         version: link:../backroad-ui
@@ -7236,12 +7239,27 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0
 
+  '@tanstack/react-virtual@3.14.2':
+    resolution:
+      {
+        integrity: sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==,
+      }
+    peerDependencies:
+      react: 18.2.0
+      react-dom: 18.2.0
+
   '@tanstack/table-core@8.21.3':
     resolution:
       {
         integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==,
       }
     engines: { node: '>=12' }
+
+  '@tanstack/virtual-core@3.17.0':
+    resolution:
+      {
+        integrity: sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==,
+      }
 
   '@testing-library/dom@9.3.4':
     resolution:
@@ -25955,7 +25973,15 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
+  '@tanstack/react-virtual@3.14.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
   '@tanstack/table-core@8.21.3': {}
+
+  '@tanstack/virtual-core@3.17.0': {}
 
   '@testing-library/dom@9.3.4':
     dependencies:


### PR DESCRIPTION
The table renderer relied on a dead `className="table"`, so cells had no padding (ids mashed into adjacent columns), no borders, and wide content overflowed the page. Restyle with the shared design tokens: cell padding, header background, row dividers, hover, sticky-safe header, and an overflow-x-auto wrapper. Guard the previously-always-rendered empty <tfoot>.

Add gated virtualization via @tanstack/react-virtual: tables over 100 rows switch to a max-h-[70vh] scroll viewport that mounts only the visible window (plus overscan) using spacer rows, preserving native column auto-sizing. Smaller tables render naturally — unchanged.

Add Table.stories.tsx (default, single-row, empty, footer, wide, long stress cases) and table.test.tsx covering behavior, the virtualization gate, and actual windowing (via mocked offsetHeight, since jsdom has no layout engine). Stub ResizeObserver in test-setup for the virtualizer.

## Summary

## <!-- 1-3 bullets on what changed and why. -->

-

## Type of change

<!-- Tick what applies. Conventional-commit prefix on the PR title should match. -->

- [ ] feat (new capability)
- [ ] fix (bug fix)
- [ ] refactor (no behaviour change)
- [ ] perf (faster / smaller / cheaper)
- [ ] docs
- [ ] chore (build, CI, deps)
- [ ] test

## Test plan

<!-- How did you verify this works? -->

- [ ] Unit tests added or updated
- [ ] E2E tests added or updated
- [ ] Manually tested in the example app
- [ ] N/A (explain)

## Risk + rollback

<!-- What breaks if this is wrong? How would you back it out? Skip for chore-only PRs. -->

## Breaking changes

<!-- If the PR title starts with `feat!` or `fix!`, list what consumers need to do. -->

---

🤖 PR-checks must pass before merge. Run `pnpm -r typecheck && pnpm -r lint && pnpm knip:ci && pnpm e2e` locally for a fast preview.
