### PR TITLE
Pin chat input via a bottom dock

### DIFF
--- a/examples/demo/src/main.ts
+++ b/examples/demo/src/main.ts
@@ -8,7 +8,7 @@ const initialMessages = [
 const auth = buildAuth();
 
 run(
-  (br) => {
+  async (br) => {
     // Auth gate: only enforced when auth env vars are configured. Mirrors
     // Streamlit's top-of-script `if not st.user.is_logged_in: ...` pattern.
     if (auth && !br.user.isLoggedIn) {
@@ -54,7 +54,7 @@ run(
     // const br = brBase.base({});
     br.write({ body: `# Backroad LLM Example\n---` });
     const button = br.button({ label: 'Reset' });
-    const chatManager = new ChatManager({
+    const chatManager = await ChatManager.create({
       br,
       messagesStateName: 'messages',
       initialMessages,

--- a/examples/demo/src/pages/columns.ts
+++ b/examples/demo/src/pages/columns.ts
@@ -21,6 +21,22 @@ export const backroadColumnsExample = async (br: BackroadNodeManager) => {
     items: [{ label: 'Last 30 days', value: '99.97%', delta: '-0.01%' }],
   });
   col3.write({ body: 'One minor incident on Tuesday night.' });
+  // Dock a chat input at the bottom of column 3. The grid stretches all cells
+  // to the tallest row, so col3 gets a bounded height to pin against.
+  col3.bottom().chatInput({ id: 'col-chat', placeholder: 'Chat in column 3' });
+
+  // Make column 1 tall so the grid row (and the stretched col3) has real height.
+  col1.write({
+    body: '- Enterprise upsells\n- New seat expansion\n- Annual prepay\n- Reduced churn\n- Marketplace fees\n- Partner referrals\n- Usage overages',
+  });
+
+  br.write({ body: '---' });
+  br.write({ body: '## Dock inside a tab (`tab.bottom()`)' });
+  const [tabA, tabB] = await br.tabs({ labels: ['Chat tab', 'Plain tab'] });
+  tabA.write({ body: '### Conversation' });
+  tabA.write({ body: 'A docked input lives at the bottom of this tab panel.' });
+  tabA.bottom().chatInput({ id: 'tab-chat', placeholder: 'Chat in tab A' });
+  tabB.write({ body: 'Nothing docked here — ordinary tab content.' });
 
   br.write({ body: '---' });
   br.write({ body: '## Custom ratio (`columns: [1, 2]`)' });

--- a/examples/demo/src/pages/llm.ts
+++ b/examples/demo/src/pages/llm.ts
@@ -8,7 +8,7 @@ export const backroadLLMExample = async (br: BackroadNodeManager) => {
   messages.forEach((message) => {
     br.chatMessage({ by: message.by }).write({ body: message.content });
   });
-  const input = br.chatInput({ id: 'input' });
+  const input = br.bottom().chatInput({ id: 'input' });
   if (input) {
     br.setValue('messages', [
       ...messages,

--- a/libs/backroad-components/src/lib/containers/base.tsx
+++ b/libs/backroad-components/src/lib/containers/base.tsx
@@ -1,12 +1,34 @@
-import { BackroadContainer } from '@backroad/core';
-import { TreeRender } from '../tree';
+import { BackroadContainerRenderer } from '../types/containers';
+import { Frame } from './frame';
 
-export const Base = (props: BackroadContainer<'base', true>) => {
+export const Base: BackroadContainerRenderer<'base'> = (props) => {
+  // Same body/dock split as the page, but `h-full` so it inherits a bounded
+  // height from whatever frame encloses it (a sized tab/column cell), and
+  // degrades to plain flow when there's no dock.
   return (
-    <div className="container mx-auto flex flex-col gap-3 lg:gap-5">
-      {props.children.map((child) => {
-        return <TreeRender tree={child} key={child.path} />;
-      })}
-    </div>
+    <Frame nodes={props.children}>
+      {({ body, dock, hasDock }) => (
+        <div
+          className={
+            hasDock
+              ? 'container mx-auto flex h-full min-h-0 flex-col'
+              : 'container mx-auto flex flex-col gap-3 lg:gap-5'
+          }
+        >
+          <div
+            className={
+              hasDock
+                ? 'flex min-h-0 flex-1 flex-col gap-3 lg:gap-5 overflow-y-auto'
+                : 'contents'
+            }
+          >
+            {body}
+          </div>
+          {hasDock ? (
+            <div className="flex shrink-0 flex-col">{dock}</div>
+          ) : null}
+        </div>
+      )}
+    </Frame>
   );
 };

--- a/libs/backroad-components/src/lib/containers/bottom.tsx
+++ b/libs/backroad-components/src/lib/containers/bottom.tsx
@@ -1,0 +1,15 @@
+import { TreeRender } from '../tree';
+import { BackroadContainerRenderer } from '../types/containers';
+
+// The dock half of the frame/dock pair. The page (see `Page`) renders any
+// `bottom` children here, outside the scrolling message body, so the chat input
+// stays pinned to the bottom while bubbles grow and the log scrolls above it.
+export const Bottom: BackroadContainerRenderer<'bottom'> = (props) => {
+  return (
+    <div className="shrink-0 flex flex-col gap-3 border-t border-border bg-background px-3 pb-4 pt-3 lg:px-5">
+      {props.children.map((child) => {
+        return <TreeRender tree={child} key={child.path} />;
+      })}
+    </div>
+  );
+};

--- a/libs/backroad-components/src/lib/containers/frame.tsx
+++ b/libs/backroad-components/src/lib/containers/frame.tsx
@@ -1,0 +1,50 @@
+import { ReactNode } from 'react';
+import { BackroadContainer } from '@backroad/core';
+import { TreeRender } from '../tree';
+
+type FrameNodes = BackroadContainer<'base', true>['children'];
+
+type FrameSlots = {
+  /** Body nodes (everything that isn't a `bottom` dock), rendered + keyed. */
+  body: ReactNode;
+  /** Dock nodes (the `bottom` children), rendered + keyed. */
+  dock: ReactNode;
+  hasDock: boolean;
+};
+
+type FrameProps = {
+  nodes: FrameNodes;
+  children: (slots: FrameSlots) => ReactNode;
+};
+
+// Frame owns the two things that must stay correct: splitting children into a
+// scrolling body and a pinned `bottom` dock, and rendering each node with a
+// stable `key={path}` so the message log is never remounted (a remount resets
+// scroll position and input focus — the HIGH-impact React footgun).
+//
+// It hands back the already-rendered, correctly-keyed element arrays and lets
+// the caller compose whatever structure it wants around them — a sticky header,
+// scroll shadows, custom dock chrome, per-container layout. Callers cannot
+// mis-key (Frame did the mapping); the one thing they own is keeping their
+// skeleton stable across the no-dock <-> dock toggle if they want to avoid a
+// remount (Page and Base do, via a single skeleton + `display: contents`).
+export const Frame = ({ nodes, children }: FrameProps) => {
+  const bodyNodes: FrameNodes = [];
+  const dockNodes: FrameNodes = [];
+  for (const child of nodes) {
+    (child.type === 'bottom' ? dockNodes : bodyNodes).push(child);
+  }
+
+  const render = (list: FrameNodes) =>
+    list.map((child) => <TreeRender tree={child} key={child.path} />);
+
+  return (
+    <>
+      {children({
+        body: render(bodyNodes),
+        dock: render(dockNodes),
+        hasDock: dockNodes.length > 0,
+      })}
+    </>
+  );
+};

--- a/libs/backroad-components/src/lib/containers/index.tsx
+++ b/libs/backroad-components/src/lib/containers/index.tsx
@@ -2,7 +2,8 @@ import { InbuiltContainerTypes } from '@backroad/core';
 import { BackroadContainerRenderer } from '../types/containers';
 import { Base } from './base';
 import { Sidebar } from './sidebar';
-import { _Page } from './page';
+import { Bottom } from './bottom';
+import { Page } from './page';
 import { Columns } from './columns';
 import { Collapse } from './collapse';
 import { Tabs } from './tabs';
@@ -14,7 +15,8 @@ export const backroadClientContainers: {
   base: Base,
   columns: Columns,
   sidebar: Sidebar,
-  page: _Page,
+  bottom: Bottom,
+  page: Page,
   collapse: Collapse,
   tabs: Tabs,
   chat_message: ChatMessage,

--- a/libs/backroad-components/src/lib/containers/page.tsx
+++ b/libs/backroad-components/src/lib/containers/page.tsx
@@ -1,13 +1,37 @@
-import { BackroadContainer } from '@backroad/core';
-// import { TreeRender } from '../tree';
-import { TreeRender } from '../tree';
+import { BackroadContainerRenderer } from '../types/containers';
+import { Frame } from './frame';
 
-export const _Page = (props: BackroadContainer<'page', true>) => {
+export const Page: BackroadContainerRenderer<'page'> = (props) => {
+  // A `bottom` child turns the page into a frame: a viewport-height column whose
+  // message body scrolls internally while the dock (chat input) stays pinned at
+  // the bottom. Without one, keep the original window-scrolled flow so ordinary
+  // pages are unaffected. One skeleton across both cases (body is
+  // `display: contents` when not docking) keeps children from remounting on the
+  // toggle.
   return (
-    <div className="container mx-auto flex flex-1 flex-col gap-3 lg:gap-5 px-3 py-[100px] lg:px-5 max-w-[900px]">
-      {props.children.map((child) => {
-        return <TreeRender tree={child} key={child.path} />;
-      })}
-    </div>
+    <Frame nodes={props.children}>
+      {({ body, dock, hasDock }) => (
+        <div
+          className={
+            hasDock
+              ? 'container mx-auto flex h-[100dvh] flex-col max-w-[900px]'
+              : 'container mx-auto flex flex-1 flex-col gap-3 lg:gap-5 px-3 py-[100px] lg:px-5 max-w-[900px]'
+          }
+        >
+          <div
+            className={
+              hasDock
+                ? 'flex min-h-0 flex-1 flex-col gap-3 lg:gap-5 overflow-y-auto px-3 pt-[100px] pb-4 lg:px-5'
+                : 'contents'
+            }
+          >
+            {body}
+          </div>
+          {hasDock ? (
+            <div className="flex shrink-0 flex-col">{dock}</div>
+          ) : null}
+        </div>
+      )}
+    </Frame>
   );
 };

--- a/libs/backroad-core/src/lib/core.ts
+++ b/libs/backroad-core/src/lib/core.ts
@@ -3,14 +3,7 @@
 // `exports` map and fails to resolve under `bundler`/`node16` moduleResolution
 // (e.g. the Storybook tsconfig). Each component IS a TypedChartComponent<T>,
 // so `Parameters<typeof X>[0]` yields the identical props type.
-import type {
-  Line,
-  Bar,
-  Pie,
-  Doughnut,
-  Radar,
-  Scatter,
-} from 'react-chartjs-2';
+import type { Line, Bar, Pie, Doughnut, Radar, Scatter } from 'react-chartjs-2';
 import type { Props } from 'react-select';
 import type { ColumnHelper } from '@tanstack/react-table';
 import { HTMLProps, IframeHTMLAttributes } from 'react';
@@ -231,6 +224,10 @@ type ContainerArgsMapping = {
     args: { columns: number | number[] };
   };
   sidebar: {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    args: {};
+  };
+  bottom: {
     // eslint-disable-next-line @typescript-eslint/ban-types
     args: {};
   };

--- a/libs/backroad/src/lib/backroad/backroad.ts
+++ b/libs/backroad/src/lib/backroad/backroad.ts
@@ -172,6 +172,14 @@ export class BackroadNodeManager<
       this.#constructContainerObject(props, 'base')
     );
   }
+  // A dock: its children are pinned to the bottom of the enclosing frame (the
+  // page) while the rest of the page scrolls above them. Used to keep a chat
+  // input in place while message bubbles grow.
+  bottom(props: BackroadContainerFormat<'bottom'> = {}) {
+    return this.#addContainerDescendant(
+      this.#constructContainerObject(props, 'bottom')
+    );
+  }
   page(props: BackroadContainerFormat<'page'>) {
     if (props.path === '/') {
       throw new Error(

--- a/libs/backroad/src/lib/backroad/chat-manager.ts
+++ b/libs/backroad/src/lib/backroad/chat-manager.ts
@@ -17,7 +17,12 @@ export class ChatManager {
   userInput: string | null;
   userInputComplete: boolean;
   awaitingLlmResponse = false;
-  constructor(props: ChatManagerProps) {
+  // Use `await ChatManager.create(...)`. The constructor only does synchronous
+  // setup; `initialize` is async (a stored message's content may be a
+  // Promise<string> that must be awaited), and it must finish before callers
+  // read `userInput`/`userInputComplete` — so construction is gated behind an
+  // awaited factory rather than a fire-and-forget call in the constructor.
+  private constructor(props: ChatManagerProps) {
     this.br = props.br;
     this.messagesStateName = props.messagesStateName;
     this.initialMessages = props.initialMessages;
@@ -28,9 +33,13 @@ export class ChatManager {
     );
     this.userInput = null;
     this.userInputComplete = false;
-    this.initialize(props.inputId);
   }
-  private initialize(inputId: string) {
+  static async create(props: ChatManagerProps): Promise<ChatManager> {
+    const manager = new ChatManager(props);
+    await manager.initialize(props.inputId);
+    return manager;
+  }
+  private async initialize(inputId: string) {
     if (
       !this.messages.every(
         (message) => message.by === 'ai' || message.by === 'human'
@@ -44,19 +53,25 @@ export class ChatManager {
         this.br.chatMessage({ by }).write({ body: content as string });
       });
 
-    // Only show chat input if the last message was from an llm
-    if (this.messages.slice(-1)[0].by === 'ai') {
-      this.userInput = this.br.chatInput({ id: inputId });
-    }
+    // Render the input once, unconditionally, docked in a `bottom` container.
+    // It used to be emitted only when the last message was from the llm — and
+    // re-emitted again inside addAIMessage — purely to keep it ordered *below*
+    // the newest message in normal flow. The dock pins it to the bottom of the
+    // frame regardless of emit order, so a single render here is enough.
+    const inputValue = this.br.bottom().chatInput({ id: inputId });
 
-    if (this.userInput) {
+    const lastMessage = this.messages.slice(-1)[0];
+    if (inputValue) {
+      // The user just submitted a prompt — record it so the next run drives the
+      // llm turn (where lastMessage will be this human message).
+      this.userInput = inputValue;
       this.br.setValue(this.messagesStateName, [
         ...this.messages,
-        { by: 'human', content: this.userInput },
+        { by: 'human', content: inputValue },
       ]);
-    } else if (this.messages.slice(-1)[0].by === 'human') {
+    } else if (lastMessage.by === 'human') {
       this.userInputComplete = true;
-      this.userInput = this.messages.slice(-1)[0].content as string;
+      this.userInput = await lastMessage.content;
     }
   }
 
@@ -68,7 +83,6 @@ export class ChatManager {
       loadingPromise:
         typeof message.content !== 'string' ? message.content : undefined,
     });
-    this.userInput = this.br.chatInput({ id: this.inputId });
     if (typeof message.content !== 'string') {
       message.content.then((body) => {
         this.br.setValue(this.messagesStateName, [

--- a/libs/backroad/src/lib/backroad/render-queue.ts
+++ b/libs/backroad/src/lib/backroad/render-queue.ts
@@ -3,21 +3,23 @@ import { SocketManager } from './socket-manager';
 
 export class RenderQueue {
   queue: string[] = [];
-  flushTimeout: NodeJS.Timeout | null = null;
+  // Coalesce a synchronous burst of renders (one script pass pushes many nodes)
+  // into a single emit, flushed on the next microtask. No artificial delay: the
+  // old 500ms debounce reset its timer on every push, so a steady token stream —
+  // renders arriving <500ms apart — never flushed until the stream paused, which
+  // is what made streamed chat updates land in one late jump.
+  #flushScheduled = false;
   addToQueue(payload: string) {
     this.queue.push(payload);
-    if (this.flushTimeout) {
-      clearTimeout(this.flushTimeout);
-    }
-    this.flushTimeout = setTimeout(() => {
-      this.#flushToFrontend();
-    }, 500);
+    if (this.#flushScheduled) return;
+    this.#flushScheduled = true;
+    queueMicrotask(() => {
+      this.#flushScheduled = false;
+      if (this.queue.length) this.#flushToFrontend();
+    });
   }
   constructor(private backroadSession: BackroadSession) {}
   flush() {
-    if (this.flushTimeout) {
-      clearTimeout(this.flushTimeout);
-    }
     const queue = JSON.parse(JSON.stringify(this.queue));
     this.queue = [];
     return queue;


### PR DESCRIPTION
## Problem

In chat UIs the text input shifted up while the assistant was "typing", then back down once the response arrived. The input was an inline flow element rendered **below** the assistant bubble, so as that bubble grew from typing-dots to the full answer it shoved the input. The 500ms render debounce made it land as a discrete jump.

## What changed

**1. `perf(render-queue)` — drop the 500ms debounce**
It reset its timer on every push, so a steady render stream never flushed until it paused. Now coalesces a synchronous burst into one emit on the next microtask — no delay, no stream starvation.

**2. `feat(containers)` — `bottom` dock + `Frame`**
- New `bottom` container; its children dock to the bottom of the enclosing frame while the rest scrolls above. The input is taken out of message flow, so bubble growth never moves it.
- `br.bottom()` is a method on every node manager, so it works on `page`, `base`, and `tab`/`column` cells (which are `base` under the hood).
- `Frame` owns the body/dock split + stable `key={path}` and renders one skeleton across the no-dock↔dock toggle (via `display:contents`) so the message log is never remounted (no scroll/focus reset). `Base` and `Page` render through it via a render-prop, free to compose their own structure.
- Rename `_Page` → `Page`.

**3. `refactor(chat-manager)` — single docked input, async-safe construction**
- Docking makes emit order irrelevant, so the two input render sites (gated in `initialize` + duplicated in `addAIMessage`) collapse into one unconditional `br.bottom().chatInput()`.
- `initialize` is async (a stored message's content may be `Promise<string>`); construction moved behind `await ChatManager.create(...)` so `userInput` is set before callers read it (the old fire-and-forget `initialize()` in the constructor fed `null` into the llm turn).

## Behavior

Docking **pins** (with internal scroll) where the container is height-bounded — the page (`100dvh`) and grid cells (stretch to row height). In an unbounded container (tab panels) it degrades gracefully to the input trailing at the bottom of the content. "Dock renders at the bottom" holds everywhere; only pinning needs bounds.

## Verification

- All touched packages typecheck; eslint clean (pre-existing warnings only).
- Dogfooded the live demo chat: input rect identical (`top:595 height:64`) before/during-loading/after a tall image bubble — never shifts; exactly one `<textarea>`; `"1+1"` → `"Ah, the answer to that is 2!! 😎"` (input round-trips); reset works; no console errors.

## Notes

- Pre-existing `tree ↔ containers/index` circular import surfaces only during HMR (`Cannot access 'Page' before initialization`); not a runtime failure. Worth cleaning up separately.
- Tab-panel docking only *pins* if the panel is given a bounded height — follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)