### PR TITLE
feat(docs): fix sandbox code indentation + auto-format samples

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,6 @@ coverage
 dist
 node_modules
 tmp
+# Raw live-sandbox samples — imported as text (?raw), not real modules.
+# Prettier still formats them; ESLint would flag the unresolved imports.
+apps/docs/src/examples

--- a/apps/docs/docs/components/charts.mdx
+++ b/apps/docs/docs/components/charts.mdx
@@ -3,6 +3,7 @@ title: Charts
 ---
 
 import { BackroadSandbox } from '@site/src/components/BackroadSandbox';
+import code from '@site/src/examples/charts.ts?raw';
 
 # Charts
 
@@ -123,36 +124,4 @@ br.bar({
 
 ## Try it
 
-<BackroadSandbox
-  height={560}
-  code={`import { run } from '@backroad/backroad';
-
-run((br) => {
-br.write({ body: '# Charts' });
-
-const points = br.numberInput({
-label: 'Number of points',
-defaultValue: 5,
-min: 2,
-max: 12,
-});
-
-const labels = Array.from({ length: points }, (\_, i) => \`P\${i + 1}\`);
-const data = labels.map(() => Math.round(Math.random() \* 100));
-
-br.line({
-data: {
-labels,
-datasets: [{ label: 'Random walk', data, borderColor: '#3b82f6' }],
-},
-});
-
-br.bar({
-data: {
-labels,
-datasets: [{ label: 'Bars', data }],
-},
-});
-});
-`}
-/>
+<BackroadSandbox height={560} code={code} />

--- a/apps/docs/docs/components/data.mdx
+++ b/apps/docs/docs/components/data.mdx
@@ -3,6 +3,7 @@ title: Data components
 ---
 
 import { BackroadSandbox } from '@site/src/components/BackroadSandbox';
+import code from '@site/src/examples/data.ts?raw';
 
 # Data components
 
@@ -65,37 +66,4 @@ br.json({
 
 ## Try it
 
-<BackroadSandbox
-  height={560}
-  code={`import { run } from '@backroad/backroad';
-
-run((br) => {
-br.write({ body: '# Data components' });
-
-br.stats({
-items: [
-{ label: 'MRR', value: '$12,430', delta: '+8.2%' },
-{ label: 'Users', value: 1842, delta: '+143' },
-{ label: 'Churn', value: '1.1%', delta: '-0.3%' },
-],
-});
-
-br.table({
-data: [
-{ name: 'Ada', team: 'Eng', joined: '2024-01-10' },
-{ name: 'Linus', team: 'Kernel', joined: '1991-09-17' },
-{ name: 'Grace', team: 'Compiler', joined: '1959-04-01' },
-],
-columns: {
-name: { header: 'Name' },
-team: { header: 'Team' },
-joined: { header: 'Joined' },
-},
-});
-
-br.json({
-src: { hello: 'world', nested: { count: 3, tags: ['a', 'b'] } },
-});
-});
-`}
-/>
+<BackroadSandbox height={560} code={code} />

--- a/apps/docs/docs/components/feedback.mdx
+++ b/apps/docs/docs/components/feedback.mdx
@@ -3,6 +3,7 @@ title: Feedback
 ---
 
 import { BackroadSandbox } from '@site/src/components/BackroadSandbox';
+import code from '@site/src/examples/feedback.ts?raw';
 
 # Feedback
 
@@ -31,26 +32,4 @@ both light and dark mode.
 
 ## Try it
 
-<BackroadSandbox
-  height={420}
-  code={`import { run } from '@backroad/backroad';
-
-run((br) => {
-br.write({ body: '# Toast demo' });
-
-const variant = br.select({
-label: 'Variant',
-options: [
-{ value: 'info', label: 'Info' },
-{ value: 'success', label: 'Success' },
-{ value: 'warning', label: 'Warning' },
-{ value: 'error', label: 'Error' },
-],
-});
-
-if (br.button({ label: 'Notify' })) {
-br.toast({ message: \`This is a \${variant ?? 'info'} toast\`, variant: variant ?? 'info' });
-}
-});
-`}
-/>
+<BackroadSandbox height={420} code={code} />

--- a/apps/docs/docs/components/inputs.mdx
+++ b/apps/docs/docs/components/inputs.mdx
@@ -3,6 +3,7 @@ title: Inputs
 ---
 
 import { BackroadSandbox } from '@site/src/components/BackroadSandbox';
+import code from '@site/src/examples/inputs.ts?raw';
 
 # Inputs
 
@@ -208,32 +209,4 @@ for (const f of files) {
 
 ## Try it
 
-<BackroadSandbox
-  height={560}
-  code={`import { run } from '@backroad/backroad';
-
-run((br) => {
-br.write({ body: '# Inputs sampler' });
-
-const name = br.textInput({ label: 'Name', defaultValue: 'Ada' });
-const age = br.numberInput({ label: 'Age', defaultValue: 30, min: 0 });
-const fav = br.select({
-label: 'Favourite colour',
-options: [
-{ value: 'red', label: 'Red' },
-{ value: 'green', label: 'Green' },
-{ value: 'blue', label: 'Blue' },
-],
-});
-const dark = br.toggle({ label: 'Dark mode' });
-
-br.write({
-body: \`Hello **\${name}** (\${age}). You like \${fav ?? '—'}. Dark: \${dark}.\`,
-});
-
-if (br.button({ label: 'Submit' })) {
-br.write({ body: 'Submitted!' });
-}
-});
-`}
-/>
+<BackroadSandbox height={560} code={code} />

--- a/apps/docs/docs/components/layout.mdx
+++ b/apps/docs/docs/components/layout.mdx
@@ -3,6 +3,7 @@ title: Layout
 ---
 
 import { BackroadSandbox } from '@site/src/components/BackroadSandbox';
+import code from '@site/src/examples/layout.ts?raw';
 
 # Layout
 
@@ -72,7 +73,7 @@ if (message) {
 ```
 
 The dock lives outside the scrolling body, so its position doesn't depend on
-*when* you emit it — render it wherever is convenient in your script and it
+_when_ you emit it — render it wherever is convenient in your script and it
 still sits at the bottom. See [LLM components](./llm) for the full chat
 pattern.
 
@@ -93,20 +94,4 @@ moreRight.write({ body: 'Hidden content.' });
 
 ## Try it
 
-<BackroadSandbox
-  height={560}
-  code={`import { run } from '@backroad/backroad';
-
-run((br) => {
-br.write({ body: '# Layout' });
-
-const [left, right] = br.columns({ columns: [1, 2] });
-left.write({ body: '## Narrow' });
-left.toggle({ label: 'Switch' });
-
-const [a, b] = right.tabs({ labels: ['Tab A', 'Tab B'] });
-a.write({ body: 'Hello from **Tab A**.' });
-b.write({ body: 'Hello from **Tab B**.' });
-});
-`}
-/>
+<BackroadSandbox height={560} code={code} />

--- a/apps/docs/docs/components/llm.mdx
+++ b/apps/docs/docs/components/llm.mdx
@@ -3,6 +3,7 @@ title: LLM components
 ---
 
 import { BackroadSandbox } from '@site/src/components/BackroadSandbox';
+import code from '@site/src/examples/llm.ts?raw';
 
 # LLM components
 
@@ -153,34 +154,4 @@ run(async (br) => {
 
 ## Try it
 
-<BackroadSandbox
-  height={560}
-  code={`import { run } from '@backroad/backroad';
-
-const history = [
-{ by: 'ai', content: 'Hi! Type something and I will echo it back.' },
-];
-
-async function\* reply(prompt) {
-for (const word of (\`Echo: \${prompt}\`).split(' ')) {
-await new Promise((r) => setTimeout(r, 80));
-yield word + ' ';
-}
-}
-
-run(async (br) => {
-br.write({ body: '# Mini chat' });
-
-for (const m of history) {
-br.chatMessage({ by: m.by }).write({ body: m.content });
-}
-
-const next = br.bottom().chatInput({ placeholder: 'Say something…' });
-if (next) {
-br.chatMessage({ by: 'human' }).write({ body: next });
-const text = await br.chatMessage({ by: 'ai' }).writeStream(reply(next));
-history.push({ by: 'human', content: next }, { by: 'ai', content: text });
-}
-});
-`}
-/>
+<BackroadSandbox height={560} code={code} />

--- a/apps/docs/docs/components/multimedia.mdx
+++ b/apps/docs/docs/components/multimedia.mdx
@@ -3,6 +3,7 @@ title: Multimedia
 ---
 
 import { BackroadSandbox } from '@site/src/components/BackroadSandbox';
+import code from '@site/src/examples/multimedia.ts?raw';
 
 # Multimedia
 
@@ -75,21 +76,4 @@ if (files.length > 0) {
 
 ## Try it
 
-<BackroadSandbox
-  height={520}
-  code={`import { run } from '@backroad/backroad';
-
-run((br) => {
-br.write({ body: '# Multimedia' });
-
-const url = br.textInput({
-label: 'Image URL',
-defaultValue: 'https://placekitten.com/640/360',
-});
-
-if (url) {
-br.image({ src: url, alt: 'preview', width: 480 });
-}
-});
-`}
-/>
+<BackroadSandbox height={520} code={code} />

--- a/apps/docs/docs/components/sidebar.mdx
+++ b/apps/docs/docs/components/sidebar.mdx
@@ -3,6 +3,7 @@ title: Sidebar
 ---
 
 import { BackroadSandbox } from '@site/src/components/BackroadSandbox';
+import code from '@site/src/examples/sidebar.ts?raw';
 
 # Sidebar
 
@@ -114,27 +115,4 @@ across pages.
 
 ## Try it
 
-<BackroadSandbox
-  height={560}
-  code={`import { run } from '@backroad/backroad';
-
-run((br) => {
-const sidebar = br.sidebar({});
-sidebar.write({ body: '## Sidebar' });
-const region = sidebar.select({
-label: 'Region',
-options: [
-{ value: 'all', label: 'All regions' },
-{ value: 'eu', label: 'EU' },
-{ value: 'us', label: 'US' },
-{ value: 'apac', label: 'APAC' },
-],
-defaultValue: 'all',
-});
-sidebar.toggle({ label: 'Include archived' });
-
-br.write({ body: '# Dashboard' });
-br.write({ body: \`Selected region: **\${region}**\` });
-});
-`}
-/>
+<BackroadSandbox height={560} code={code} />

--- a/apps/docs/docs/components/writing-and-markdown.mdx
+++ b/apps/docs/docs/components/writing-and-markdown.mdx
@@ -3,6 +3,7 @@ title: Writing & markdown
 ---
 
 import { BackroadSandbox } from '@site/src/components/BackroadSandbox';
+import code from '@site/src/examples/writing-and-markdown.ts?raw';
 
 # Writing & markdown
 
@@ -100,32 +101,4 @@ br.write({ body: `Hello, **${name}**!` });
 
 ## Try it
 
-<BackroadSandbox
-  height={520}
-  code={`import { run } from '@backroad/backroad';
-
-run((br) => {
-br.title({ label: 'Markdown demo' });
-
-const name = br.textInput({
-label: 'Your name',
-defaultValue: 'Ada',
-});
-
-br.write({
-body: \`
-
-## Hello, **\${name}**!
-
-Backroad renders **GFM markdown**:
-
-- lists
-- _italic_
-- tables, blockquotes, fenced code blocks
-
-Tip: re-runs are cheap. Type freely.
-\`,
-});
-});
-`}
-/>
+<BackroadSandbox height={520} code={code} />

--- a/apps/docs/docs/configuration/themes.mdx
+++ b/apps/docs/docs/configuration/themes.mdx
@@ -3,6 +3,7 @@ title: Themes
 ---
 
 import { BackroadSandbox } from '@site/src/components/BackroadSandbox';
+import code from '@site/src/examples/themes.ts?raw';
 
 # Themes
 
@@ -69,23 +70,4 @@ palette override beyond the `appearance` recommendation above.
 
 ## Try it
 
-<BackroadSandbox
-  height={520}
-  code={`import { run } from '@backroad/backroad';
-
-run(
-(br) => {
-br.write({ body: '# Themed sandbox' });
-br.write({
-body: 'Open the settings menu (top-right) to change palette and mode.',
-});
-
-    if (br.button({ label: 'Primary action' })) {
-      br.write({ body: 'Clicked.' });
-    }
-
-},
-{ appearance: { theme: 'claude', mode: 'light' } }
-);
-`}
-/>
+<BackroadSandbox height={520} code={code} />

--- a/apps/docs/docs/fundamentals/components.mdx
+++ b/apps/docs/docs/fundamentals/components.mdx
@@ -3,6 +3,7 @@ title: Components
 ---
 
 import { BackroadSandbox } from '@site/src/components/BackroadSandbox';
+import code from '@site/src/examples/components.ts?raw';
 
 # Components
 
@@ -71,27 +72,4 @@ Each is documented under [Components](../components/writing-and-markdown).
 
 ## Try it
 
-<BackroadSandbox
-  height={520}
-  code={`import { run } from '@backroad/backroad';
-
-run((br) => {
-br.title({ label: 'Components in one place' });
-
-const name = br.textInput({
-label: 'Name',
-defaultValue: 'Ada',
-});
-
-const excited = br.toggle({ label: 'Excited?' });
-
-br.write({
-body: \`Hello, **\${name}**\${excited ? '!!!' : '.'}\`,
-});
-
-if (br.button({ label: 'Click me' })) {
-br.write({ body: 'Button was clicked.' });
-}
-});
-`}
-/>
+<BackroadSandbox height={520} code={code} />

--- a/apps/docs/docs/fundamentals/containers.mdx
+++ b/apps/docs/docs/fundamentals/containers.mdx
@@ -3,6 +3,7 @@ title: Containers
 ---
 
 import { BackroadSandbox } from '@site/src/components/BackroadSandbox';
+import code from '@site/src/examples/containers.ts?raw';
 
 # Containers
 
@@ -103,22 +104,4 @@ run((br) => {
 
 ## Try it
 
-<BackroadSandbox
-  height={520}
-  code={`import { run } from '@backroad/backroad';
-
-run((br) => {
-br.write({ body: '# Containers demo' });
-
-const [left, right] = br.columns({ columns: 2 });
-left.write({ body: '## Left column' });
-if (left.button({ label: 'Left' })) {
-left.write({ body: 'Left clicked!' });
-}
-
-right.write({ body: '## Right column' });
-const more = right.collapse({ label: 'Show more' });
-more.write({ body: 'Hidden until you expand the panel.' });
-});
-`}
-/>
+<BackroadSandbox height={520} code={code} />

--- a/apps/docs/docs/try-it.mdx
+++ b/apps/docs/docs/try-it.mdx
@@ -4,6 +4,7 @@ sidebar_position: 3
 ---
 
 import { BackroadSandbox } from '@site/src/components/BackroadSandbox';
+import code from '@site/src/examples/try-it.ts?raw';
 
 # Try Backroad live in your browser
 
@@ -21,28 +22,7 @@ site, so later runs — here or on any other docs page — install offline (no
 re-downloading) and start much faster.
 :::
 
-<BackroadSandbox
-  height={520}
-  code={`import { run } from '@backroad/backroad';
-
-run((br) => {
-br.write({ body: '# Hello, Backroad' });
-
-const name = br.textInput({
-label: 'Your name',
-defaultValue: 'world',
-});
-
-if (name) {
-br.write({ body: \`Hello, **\${name}**!\` });
-}
-
-if (br.button({ label: 'Click me' })) {
-br.write({ body: 'Clicked!' });
-}
-});
-`}
-/>
+<BackroadSandbox height={520} code={code} />
 
 ## What works in the sandbox
 

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -37,6 +37,9 @@ const config: Config = {
       },
     ],
     './plugins/webcontainer-webpack-plugin.ts',
+    // Lets the live-sandbox MDX import each example's source from a real `.ts`
+    // file via `?raw` (so Prettier formats the samples on commit).
+    './plugins/raw-loader-plugin.ts',
     // Local client-side search — no API key or subscription required.
     // Indexes the built HTML at build time; query runs in-browser via Lunr.js.
     'docusaurus-lunr-search',

--- a/apps/docs/plugins/raw-loader-plugin.ts
+++ b/apps/docs/plugins/raw-loader-plugin.ts
@@ -1,0 +1,28 @@
+import type { Plugin } from '@docusaurus/types';
+
+// Lets MDX/TSX import a file's verbatim text with a `?raw` query, e.g.
+//   import code from '@site/src/examples/try-it.ts?raw';
+// We use this for the live `<BackroadSandbox code={...} />` samples: each
+// example lives in a real `.ts` file (formatted by Prettier on commit, just
+// like any other source) instead of an unindented template literal inlined in
+// the MDX. webpack 5's built-in `asset/source` type returns the raw contents
+// as a string, so no extra loader dependency is needed. The rule has to apply
+// to both the client and server (prerender) bundles, since the MDX import is
+// resolved in both.
+export default function rawLoaderPlugin(): Plugin {
+  return {
+    name: 'raw-loader-plugin',
+    configureWebpack() {
+      return {
+        module: {
+          rules: [
+            {
+              resourceQuery: /raw/,
+              type: 'asset/source',
+            },
+          ],
+        },
+      };
+    },
+  };
+}

--- a/apps/docs/plugins/raw-loader-plugin.ts
+++ b/apps/docs/plugins/raw-loader-plugin.ts
@@ -9,10 +9,31 @@ import type { Plugin } from '@docusaurus/types';
 // as a string, so no extra loader dependency is needed. The rule has to apply
 // to both the client and server (prerender) bundles, since the MDX import is
 // resolved in both.
+//
+// The catch: our example files are `.ts`, so Docusaurus's own `/\.[jt]sx?$/`
+// babel-loader rule ALSO matches them. webpack runs loaders first and only then
+// applies the module `type`, so without intervention babel would transpile (and
+// in production minify) the source, and `asset/source` would capture that
+// mangled JS — `import { run } from '...'` arrives in the editor as
+// `import{run}from'...'`. We therefore exclude `?raw` resources from the
+// JS/TS rule so only `asset/source` handles them, yielding the file verbatim.
 export default function rawLoaderPlugin(): Plugin {
   return {
     name: 'raw-loader-plugin',
-    configureWebpack() {
+    configureWebpack(config) {
+      // Stop the JS/TS loader (babel) from also matching our `?raw` imports;
+      // otherwise it transpiles the file before `asset/source` reads it.
+      for (const rule of config.module?.rules ?? []) {
+        if (
+          rule &&
+          typeof rule === 'object' &&
+          'test' in rule &&
+          rule.test instanceof RegExp &&
+          rule.test.test('example.ts')
+        ) {
+          rule.resourceQuery = { not: [/raw/] };
+        }
+      }
       return {
         module: {
           rules: [

--- a/apps/docs/src/examples/charts.ts
+++ b/apps/docs/src/examples/charts.ts
@@ -1,0 +1,29 @@
+import { run } from '@backroad/backroad';
+
+run((br) => {
+  br.write({ body: '# Charts' });
+
+  const points = br.numberInput({
+    label: 'Number of points',
+    defaultValue: 5,
+    min: 2,
+    max: 12,
+  });
+
+  const labels = Array.from({ length: points }, (_, i) => `P${i + 1}`);
+  const data = labels.map(() => Math.round(Math.random() * 100));
+
+  br.line({
+    data: {
+      labels,
+      datasets: [{ label: 'Random walk', data, borderColor: '#3b82f6' }],
+    },
+  });
+
+  br.bar({
+    data: {
+      labels,
+      datasets: [{ label: 'Bars', data }],
+    },
+  });
+});

--- a/apps/docs/src/examples/components.ts
+++ b/apps/docs/src/examples/components.ts
@@ -1,0 +1,20 @@
+import { run } from '@backroad/backroad';
+
+run((br) => {
+  br.title({ label: 'Components in one place' });
+
+  const name = br.textInput({
+    label: 'Name',
+    defaultValue: 'Ada',
+  });
+
+  const excited = br.toggle({ label: 'Excited?' });
+
+  br.write({
+    body: `Hello, **${name}**${excited ? '!!!' : '.'}`,
+  });
+
+  if (br.button({ label: 'Click me' })) {
+    br.write({ body: 'Button was clicked.' });
+  }
+});

--- a/apps/docs/src/examples/containers.ts
+++ b/apps/docs/src/examples/containers.ts
@@ -1,0 +1,15 @@
+import { run } from '@backroad/backroad';
+
+run((br) => {
+  br.write({ body: '# Containers demo' });
+
+  const [left, right] = br.columns({ columns: 2 });
+  left.write({ body: '## Left column' });
+  if (left.button({ label: 'Left' })) {
+    left.write({ body: 'Left clicked!' });
+  }
+
+  right.write({ body: '## Right column' });
+  const more = right.collapse({ label: 'Show more' });
+  more.write({ body: 'Hidden until you expand the panel.' });
+});

--- a/apps/docs/src/examples/data.ts
+++ b/apps/docs/src/examples/data.ts
@@ -1,0 +1,30 @@
+import { run } from '@backroad/backroad';
+
+run((br) => {
+  br.write({ body: '# Data components' });
+
+  br.stats({
+    items: [
+      { label: 'MRR', value: '$12,430', delta: '+8.2%' },
+      { label: 'Users', value: 1842, delta: '+143' },
+      { label: 'Churn', value: '1.1%', delta: '-0.3%' },
+    ],
+  });
+
+  br.table({
+    data: [
+      { name: 'Ada', team: 'Eng', joined: '2024-01-10' },
+      { name: 'Linus', team: 'Kernel', joined: '1991-09-17' },
+      { name: 'Grace', team: 'Compiler', joined: '1959-04-01' },
+    ],
+    columns: {
+      name: { header: 'Name' },
+      team: { header: 'Team' },
+      joined: { header: 'Joined' },
+    },
+  });
+
+  br.json({
+    src: { hello: 'world', nested: { count: 3, tags: ['a', 'b'] } },
+  });
+});

--- a/apps/docs/src/examples/feedback.ts
+++ b/apps/docs/src/examples/feedback.ts
@@ -1,0 +1,22 @@
+import { run } from '@backroad/backroad';
+
+run((br) => {
+  br.write({ body: '# Toast demo' });
+
+  const variant = br.select({
+    label: 'Variant',
+    options: [
+      { value: 'info', label: 'Info' },
+      { value: 'success', label: 'Success' },
+      { value: 'warning', label: 'Warning' },
+      { value: 'error', label: 'Error' },
+    ],
+  });
+
+  if (br.button({ label: 'Notify' })) {
+    br.toast({
+      message: `This is a ${variant ?? 'info'} toast`,
+      variant: variant ?? 'info',
+    });
+  }
+});

--- a/apps/docs/src/examples/inputs.ts
+++ b/apps/docs/src/examples/inputs.ts
@@ -1,0 +1,25 @@
+import { run } from '@backroad/backroad';
+
+run((br) => {
+  br.write({ body: '# Inputs sampler' });
+
+  const name = br.textInput({ label: 'Name', defaultValue: 'Ada' });
+  const age = br.numberInput({ label: 'Age', defaultValue: 30, min: 0 });
+  const fav = br.select({
+    label: 'Favourite colour',
+    options: [
+      { value: 'red', label: 'Red' },
+      { value: 'green', label: 'Green' },
+      { value: 'blue', label: 'Blue' },
+    ],
+  });
+  const dark = br.toggle({ label: 'Dark mode' });
+
+  br.write({
+    body: `Hello **${name}** (${age}). You like ${fav ?? '—'}. Dark: ${dark}.`,
+  });
+
+  if (br.button({ label: 'Submit' })) {
+    br.write({ body: 'Submitted!' });
+  }
+});

--- a/apps/docs/src/examples/layout.ts
+++ b/apps/docs/src/examples/layout.ts
@@ -1,0 +1,13 @@
+import { run } from '@backroad/backroad';
+
+run((br) => {
+  br.write({ body: '# Layout' });
+
+  const [left, right] = br.columns({ columns: [1, 2] });
+  left.write({ body: '## Narrow' });
+  left.toggle({ label: 'Switch' });
+
+  const [a, b] = right.tabs({ labels: ['Tab A', 'Tab B'] });
+  a.write({ body: 'Hello from **Tab A**.' });
+  b.write({ body: 'Hello from **Tab B**.' });
+});

--- a/apps/docs/src/examples/llm.ts
+++ b/apps/docs/src/examples/llm.ts
@@ -1,0 +1,27 @@
+import { run } from '@backroad/backroad';
+
+const history = [
+  { by: 'ai', content: 'Hi! Type something and I will echo it back.' },
+];
+
+async function* reply(prompt) {
+  for (const word of `Echo: ${prompt}`.split(' ')) {
+    await new Promise((r) => setTimeout(r, 80));
+    yield word + ' ';
+  }
+}
+
+run(async (br) => {
+  br.write({ body: '# Mini chat' });
+
+  for (const m of history) {
+    br.chatMessage({ by: m.by }).write({ body: m.content });
+  }
+
+  const next = br.bottom().chatInput({ placeholder: 'Say something…' });
+  if (next) {
+    br.chatMessage({ by: 'human' }).write({ body: next });
+    const text = await br.chatMessage({ by: 'ai' }).writeStream(reply(next));
+    history.push({ by: 'human', content: next }, { by: 'ai', content: text });
+  }
+});

--- a/apps/docs/src/examples/multimedia.ts
+++ b/apps/docs/src/examples/multimedia.ts
@@ -1,0 +1,14 @@
+import { run } from '@backroad/backroad';
+
+run((br) => {
+  br.write({ body: '# Multimedia' });
+
+  const url = br.textInput({
+    label: 'Image URL',
+    defaultValue: 'https://placekitten.com/640/360',
+  });
+
+  if (url) {
+    br.image({ src: url, alt: 'preview', width: 480 });
+  }
+});

--- a/apps/docs/src/examples/sidebar.ts
+++ b/apps/docs/src/examples/sidebar.ts
@@ -1,0 +1,20 @@
+import { run } from '@backroad/backroad';
+
+run((br) => {
+  const sidebar = br.sidebar({});
+  sidebar.write({ body: '## Sidebar' });
+  const region = sidebar.select({
+    label: 'Region',
+    options: [
+      { value: 'all', label: 'All regions' },
+      { value: 'eu', label: 'EU' },
+      { value: 'us', label: 'US' },
+      { value: 'apac', label: 'APAC' },
+    ],
+    defaultValue: 'all',
+  });
+  sidebar.toggle({ label: 'Include archived' });
+
+  br.write({ body: '# Dashboard' });
+  br.write({ body: `Selected region: **${region}**` });
+});

--- a/apps/docs/src/examples/themes.ts
+++ b/apps/docs/src/examples/themes.ts
@@ -1,0 +1,15 @@
+import { run } from '@backroad/backroad';
+
+run(
+  (br) => {
+    br.write({ body: '# Themed sandbox' });
+    br.write({
+      body: 'Open the settings menu (top-right) to change palette and mode.',
+    });
+
+    if (br.button({ label: 'Primary action' })) {
+      br.write({ body: 'Clicked.' });
+    }
+  },
+  { appearance: { theme: 'claude', mode: 'light' } }
+);

--- a/apps/docs/src/examples/try-it.ts
+++ b/apps/docs/src/examples/try-it.ts
@@ -1,0 +1,18 @@
+import { run } from '@backroad/backroad';
+
+run((br) => {
+  br.write({ body: '# Hello, Backroad' });
+
+  const name = br.textInput({
+    label: 'Your name',
+    defaultValue: 'world',
+  });
+
+  if (name) {
+    br.write({ body: `Hello, **${name}**!` });
+  }
+
+  if (br.button({ label: 'Click me' })) {
+    br.write({ body: 'Clicked!' });
+  }
+});

--- a/apps/docs/src/examples/writing-and-markdown.ts
+++ b/apps/docs/src/examples/writing-and-markdown.ts
@@ -1,0 +1,25 @@
+import { run } from '@backroad/backroad';
+
+run((br) => {
+  br.title({ label: 'Markdown demo' });
+
+  const name = br.textInput({
+    label: 'Your name',
+    defaultValue: 'Ada',
+  });
+
+  br.write({
+    body: `
+
+## Hello, **${name}**!
+
+Backroad renders **GFM markdown**:
+
+- lists
+- _italic_
+- tables, blockquotes, fenced code blocks
+
+Tip: re-runs are cheap. Type freely.
+`,
+  });
+});

--- a/apps/docs/src/raw.d.ts
+++ b/apps/docs/src/raw.d.ts
@@ -1,0 +1,6 @@
+// `?raw` imports (see plugins/raw-loader-plugin.ts) resolve to the file's
+// verbatim text as a string. Declared here so TS knows the shape.
+declare module '*?raw' {
+  const content: string;
+  export default content;
+}

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -8,5 +8,8 @@
     "ignoreDeprecations": "6.0",
     "strict": true
   },
-  "exclude": [".docusaurus", "build"]
+  // src/examples/*.ts are raw sandbox samples imported as text (?raw); they
+  // import `@backroad/backroad`, which isn't a docs dependency, so they must
+  // not be type-checked here. Prettier still formats them on commit.
+  "exclude": [".docusaurus", "build", "src/examples"]
 }


### PR DESCRIPTION
## Problem

The live `<BackroadSandbox code={...} />` samples throughout the docs rendered **flush-left** — every line started at column 0, no indentation (see the "Try it" page's Mini chat example).

**Root cause:** each sample was an inline template literal inside the MDX. Any indentation in that literal leaks into the CodeMirror editor, so whoever wrote them stripped *all* leading whitespace — losing the code's own indentation too. And Prettier can't reach JS embedded in an MDX string, so there was no way to auto-format them.

## Fix

Each sample now lives in a real `apps/docs/src/examples/*.ts` file, imported as raw text:

- **`plugins/raw-loader-plugin.ts`** — new plugin mapping `?raw` imports to webpack's built-in `asset/source` (no new dependency). Registered in `docusaurus.config.ts`.
- **`src/examples/*.ts`** — 13 extracted samples, properly indented.
- **13 MDX files** — now `import code from '@site/src/examples/<name>.ts?raw'` and `code={code}`; all other props (`height`, etc.) untouched.
- **`src/raw.d.ts`** — typing for `?raw` imports.
- **`tsconfig.json` / `.eslintignore`** — examples excluded from tsc/ESLint (they import `@backroad/backroad`, not a docs dep) but kept in Prettier.

## Automated going forward

The lefthook pre-commit hook already runs `prettier --write` on staged files. Since the samples are now real `.ts` files, **every future edit is formatted and indented automatically** — no manual whitespace fiddling.

## Verification

- `docusaurus build` — client + server both compile, `?raw` resolves ✅
- 0 leftover inline `code={\`` blocks, 13 `?raw` imports, 0 leftover escape artifacts ✅
- Spot-checked output (incl. the Mini chat sample from the bug report) — correctly indented ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated documentation “Try it” sandboxes to source their sample code from shared TypeScript snippets, improving consistency and maintainability across charts, data, feedback, inputs, layout, LLM, multimedia, sidebar, and writing/markdown pages.
* **New Features**
  * Added new runnable docs example scripts for the centralized sandbox content (e.g., charts, containers, feedback, inputs, layout, LLM, multimedia, sidebar, themes, and try-it).
* **Chores**
  * Enhanced docs tooling to support raw-imported example code and adjusted formatting/lint handling accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->