### PR TITLE
fix: drop stale render patches from superseded reruns

### DIFF
--- a/libs/backroad-components/src/lib/containers/frame.tsx
+++ b/libs/backroad-components/src/lib/containers/frame.tsx
@@ -32,6 +32,10 @@ export const Frame = ({ nodes, children }: FrameProps) => {
   const bodyNodes: FrameNodes = [];
   const dockNodes: FrameNodes = [];
   for (const child of nodes) {
+    // Defensive: a child can be a hole/null if a stale render patch ever slips
+    // past the runId gate. Skip it rather than deref `.type` and crash the whole
+    // tree render.
+    if (!child) continue;
     (child.type === 'bottom' ? dockNodes : bodyNodes).push(child);
   }
 

--- a/libs/backroad-core/src/lib/events.ts
+++ b/libs/backroad-core/src/lib/events.ts
@@ -75,7 +75,12 @@ export type BackroadEventsMapping = {
     response?: void;
   };
   render: {
-    args: string[]; //BackroadNode<true, false>;
+    // `nodes` are the superjson-encoded tree patches; `runId` stamps the run
+    // that produced them so the client can drop patches from a superseded run
+    // (an async rerun that's still emitting after a newer run reset the tree).
+    // Positional indices in node paths are only contiguous within a single run,
+    // so applying a stale patch would punch holes in the children arrays.
+    args: { nodes: string[]; runId: number }; //BackroadNode<true, false>;
     response?: void;
   };
   running: {

--- a/libs/backroad-frontend/src/app/app.tsx
+++ b/libs/backroad-frontend/src/app/app.tsx
@@ -130,7 +130,7 @@ export function App() {
     return () => {
       socket.off('render', onRender);
     };
-  });
+  }, []);
 
   console.log('pages data', treeStruct);
   const nonPageChildren = treeStruct.children.filter((c) => c.type !== 'page');

--- a/libs/backroad-frontend/src/app/app.tsx
+++ b/libs/backroad-frontend/src/app/app.tsx
@@ -6,7 +6,7 @@ import {
 import { TreeRender, socket } from 'backroad-components';
 import { Toaster } from 'backroad-ui';
 import { set } from 'lodash';
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import ReactGA from 'react-ga4';
 import { Route, Routes, useLocation } from 'react-router-dom';
 import superjson from 'superjson';
@@ -44,6 +44,11 @@ export function App() {
   const [treeStruct, setTreeStruct] = useState<BackroadContainer<'base', true>>(
     getInitialTreeStructure()
   );
+  // Highest runId whose render patch we've applied. Patches arriving with a
+  // lower runId belong to a superseded run and are ignored. -1 so the first
+  // run (runId 1) is always accepted; reset on remount, which is fine because a
+  // remount also resets treeStruct to the initial structure.
+  const lastRunIdRef = useRef(-1);
   // Keep `connected` in sync with the socket (drives the Navbar indicator).
   // `socket` is a module-level singleton — it may already be connected by the
   // time this mounts (especially with the larger better-auth-ui bundle), so
@@ -87,12 +92,28 @@ export function App() {
   }, [appearance, seedDefaults]);
 
   useEffect(() => {
-    const onRender = (nodeData: string[], callback: () => void) => {
+    const onRender = (
+      { nodes, runId }: { nodes: string[]; runId: number },
+      callback: () => void
+    ) => {
+      // Drop patches from a superseded run. Node paths carry absolute child
+      // indices that are only contiguous within a single run, so applying a
+      // stale patch on top of a freshly-reset tree would punch holes in the
+      // children arrays (which then serialize to `null` and crash the renderer).
+      if (runId < lastRunIdRef.current) {
+        callback();
+        return;
+      }
+      lastRunIdRef.current = runId;
       setTreeStruct((oldTreeStruct) => {
-        let newTree = JSON.parse(
-          JSON.stringify(oldTreeStruct)
-        ) as BackroadContainer<'base', true>;
-        nodeData.forEach((node) => {
+        // structuredClone (not JSON round-trip): if a hole ever does slip into a
+        // children array, this preserves it as a hole — which .map/.filter skip
+        // — instead of materializing it into a `null` the renderer would deref.
+        let newTree = structuredClone(oldTreeStruct) as BackroadContainer<
+          'base',
+          true
+        >;
+        nodes.forEach((node) => {
           const parsedNode = superjson.parse(node) as BackroadNode<true, true>;
           if (parsedNode.path == '') {
             // basically means a full reset

--- a/libs/backroad/src/lib/backroad/backroad.test.ts
+++ b/libs/backroad/src/lib/backroad/backroad.test.ts
@@ -87,6 +87,59 @@ describe('br.logout', () => {
   });
 });
 
+describe('render queue runId stamping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The flush is coalesced onto a microtask, so let it run.
+  const flushMicrotasks = () => Promise.resolve();
+
+  it('stamps emitted patches with the run that produced them', async () => {
+    const { session, emit } = makeSession('rq-stamp');
+    session.runId = 7;
+    session.renderQueue.addToQueue('node-a');
+    await flushMicrotasks();
+    expect(emit).toHaveBeenCalledWith(
+      'render',
+      { nodes: ['node-a'], runId: 7 },
+      expect.any(Function)
+    );
+  });
+
+  it('splits a coalesced flush into one emit per run group', async () => {
+    const { session, emit } = makeSession('rq-split');
+    // Two patches pushed in the same tick but produced by different runs (an
+    // older async run still emitting while a newer run has taken over) must not
+    // share a runId — otherwise the stale patch would slip past the client gate.
+    session.runId = 1;
+    session.renderQueue.addToQueue('old');
+    session.runId = 2;
+    session.renderQueue.addToQueue('new');
+    await flushMicrotasks();
+
+    const renderCalls = emit.mock.calls.filter(([event]) => event === 'render');
+    expect(renderCalls).toHaveLength(2);
+    expect(renderCalls[0]).toEqual([
+      'render',
+      { nodes: ['old'], runId: 1 },
+      expect.any(Function),
+    ]);
+    expect(renderCalls[1]).toEqual([
+      'render',
+      { nodes: ['new'], runId: 2 },
+      expect.any(Function),
+    ]);
+  });
+
+  it('bumps runId on resetTree so post-reset patches outrank pre-reset ones', () => {
+    const { session } = makeSession('rq-reset');
+    const before = session.runId;
+    session.resetTree();
+    expect(session.runId).toBe(before + 1);
+  });
+});
+
 describe('components', () => {
   it('adds iframe nodes as a first-class component', () => {
     const { session } = makeSession('component-iframe');

--- a/libs/backroad/src/lib/backroad/render-queue.ts
+++ b/libs/backroad/src/lib/backroad/render-queue.ts
@@ -1,8 +1,10 @@
 import { BackroadSession } from '../server/sessions/session';
 import { SocketManager } from './socket-manager';
 
+type QueuedNode = { payload: string; runId: number };
+
 export class RenderQueue {
-  queue: string[] = [];
+  queue: QueuedNode[] = [];
   // Coalesce a synchronous burst of renders (one script pass pushes many nodes)
   // into a single emit, flushed on the next microtask. No artificial delay: the
   // old 500ms debounce reset its timer on every push, so a steady token stream —
@@ -10,7 +12,10 @@ export class RenderQueue {
   // is what made streamed chat updates land in one late jump.
   #flushScheduled = false;
   addToQueue(payload: string) {
-    this.queue.push(payload);
+    // Stamp with the run that produced this patch (NOT the run that happens to
+    // be current at flush time) so a superseded async run's late patches stay
+    // labelled with their stale runId and get dropped by the client.
+    this.queue.push({ payload, runId: this.backroadSession.runId });
     if (this.#flushScheduled) return;
     this.#flushScheduled = true;
     queueMicrotask(() => {
@@ -20,16 +25,28 @@ export class RenderQueue {
   }
   constructor(private backroadSession: BackroadSession) {}
   flush() {
-    const queue = JSON.parse(JSON.stringify(this.queue));
+    const queue = this.queue;
     this.queue = [];
     return queue;
   }
   #flushToFrontend() {
     const socket = SocketManager.getSocket(this.backroadSession.sessionId);
-    const nodesToEmit = this.flush();
-    socket.emit('render', nodesToEmit, () => {
-      /* ack ignored */
-    });
+    const nodes = this.flush();
+    // A single coalesced flush can (when async runs overlap) contain patches
+    // from more than one run. Emit one `render` per contiguous run group so each
+    // batch carries a single, accurate runId for the client gate.
+    let i = 0;
+    while (i < nodes.length) {
+      const runId = nodes[i].runId;
+      const group: string[] = [];
+      while (i < nodes.length && nodes[i].runId === runId) {
+        group.push(nodes[i].payload);
+        i++;
+      }
+      socket.emit('render', { nodes: group, runId }, () => {
+        /* ack ignored */
+      });
+    }
   }
   updateProps(props: any) {
     const socket = SocketManager.getSocket(this.backroadSession.sessionId);

--- a/libs/backroad/src/lib/server/sessions/session.ts
+++ b/libs/backroad/src/lib/server/sessions/session.ts
@@ -38,6 +38,13 @@ export class BackroadSession {
   renderQueue: RenderQueue;
   rootNodeManager: BackroadNodeManager<'base'>;
   user: BackroadUser = { isLoggedIn: false };
+  // Monotonic run counter, bumped on every resetTree (i.e. every rerun). Each
+  // render patch is stamped with the runId that produced it (see RenderQueue),
+  // and the client drops any patch from a run older than the latest reset. This
+  // is what makes overlapping async reruns safe: a slow run that keeps emitting
+  // after a newer run has reset the tree can no longer corrupt it, because its
+  // patches carry a stale runId and are ignored.
+  runId = 0;
   // uploadManager: UploadManager;
   constructor(sessionId: string) {
     // this.uploadManager = new UploadManager();
@@ -57,6 +64,10 @@ export class BackroadSession {
   }
   resetTree() {
     this.renderQueue.flush(); // get rid of all pending flush commands
+    // Bump BEFORE reset so the reset payload and every node this run appends are
+    // stamped with the new runId; patches still queued/in-flight from the prior
+    // run keep their older id and get dropped by the client.
+    this.runId++;
     this.rootNodeManager.reset(getInitialTreeStructure());
   }
 


### PR DESCRIPTION
Closes #46

## Problem

The renderer crashes with `TypeError: Cannot read properties of null (reading 'type')` (at `Frame`, `frame.tsx:35` → `child.type`) when a consumer app triggers overlapping/async reruns.

### Root cause

Each render patch's node path carries **absolute child indices** (`children.N`, where `N = container.children.length` at build time — `backroad.ts:176`). Those indices are only contiguous **within a single run**. Runs are not serialized: `set_value` / `run_script` / `unset_value` each start a fresh `runExecutor` (`runner/index.ts`), and `executor` can be async (streaming, fetch). So a slow run can keep emitting patches *after* a newer run has already `resetTree()`'d to a short tree.

When a stale `children.17` lands on a freshly-reset length-2 array:
1. lodash `set` punches a **sparse array** (holes),
2. the next `JSON.parse(JSON.stringify(tree))` round-trip in `onRender` **materializes the holes as `null`**,
3. `Frame`'s `for...of` reads `null.type` → crash.

`.filter`/`.map` at the app root skip holes, which is why the top-level survived but the page body crashed.

## Fix

- **Run generation gate (correctness):** add a monotonic `runId` on the session, bumped in `resetTree()`. Every render patch is stamped with the run that produced it; the client (`app.tsx onRender`) ignores any patch from a run older than the latest reset. A superseded run's late patches can no longer corrupt the tree.
- **Per-run batching:** `RenderQueue` stamps each queued node with its `runId` and emits one `render` batch per contiguous run group, so each batch carries a single accurate `runId`. The `render` event arg becomes `{ nodes, runId }`.
- **Defense-in-depth:** clone the tree with `structuredClone` (preserves holes *as holes* — skipped by `.map`/`.filter` — instead of turning them into `null`), and skip null children in `Frame`.

## Tests

- New unit tests in `backroad.test.ts` covering runId stamping, per-run batch splitting, and the `resetTree` bump.
- `pnpm typecheck` ✅ · `pnpm test` (10 backroad + 21 frontend) ✅ · `pnpm lint` (0 errors) ✅ · `pnpm e2e` (19 passed) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when a component render encounters invalid/empty children.
  * Ensured outdated render updates from superseded operations are ignored, avoiding incorrect tree state.
* **Performance**
  * Optimized frontend tree cloning during render updates to better preserve structure and improve speed.
* **Tests**
  * Added coverage for render-queue behavior to verify correct run ordering and patch grouping.
* **API / Integration Update**
  * Updated render event payloads to include a run identifier and node list for safer client-side gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->