### PR TITLE
test(e2e): assert real download contents instead of flaky echo

### DIFF
--- a/e2e/download-button.spec.ts
+++ b/e2e/download-button.spec.ts
@@ -1,9 +1,10 @@
+import { readFile } from 'node:fs/promises';
 import { expect, test } from '@playwright/test';
 
 // Runs under the `chromium` project (already authenticated via the saved
 // storage state). The /widgets demo page renders a download_button that emits a
-// JSON file and echoes a confirmation back into the page, so we verify both the
-// real browser download and the server round-trip (click → script reruns → echo).
+// JSON file, so we verify the real browser download end-to-end: the suggested
+// filename and the actual file contents written to disk.
 
 test.describe('download_button', () => {
   test.beforeEach(async ({ page }) => {
@@ -19,7 +20,7 @@ test.describe('download_button', () => {
     ).toBeVisible();
   });
 
-  test('downloads the file and echoes the round-trip on click', async ({
+  test('downloads the file with the expected contents on click', async ({
     page,
   }) => {
     const downloadPromise = page.waitForEvent('download');
@@ -28,10 +29,10 @@ test.describe('download_button', () => {
     const download = await downloadPromise;
     expect(download.suggestedFilename()).toBe('backroad-report.json');
 
-    // The click also commits value true, so the server reruns and renders the
-    // confirmation echo.
-    await expect(page.getByText('Report downloaded!')).toBeVisible({
-      timeout: 10_000,
-    });
+    // Verify the actual bytes that hit the disk rather than the in-page echo,
+    // which is unset on the very next rerun and only flashes momentarily.
+    const path = await download.path();
+    const contents = await readFile(path, 'utf-8');
+    expect(JSON.parse(contents)).toEqual({ status: 'ok' });
   });
 });

--- a/examples/demo/src/pages/widgets.ts
+++ b/examples/demo/src/pages/widgets.ts
@@ -43,8 +43,8 @@ export const backroadWidgetsExample = (br: BackroadNodeManager) => {
   }
 
   // `downloaded` is true only on the run right after the click, so the echo
-  // below renders once per press — letting the e2e spec assert the round-trip
-  // in addition to intercepting the actual browser download.
+  // below flashes once per press as a UI affordance. The e2e spec asserts the
+  // real download (filename + file contents), not this transient echo.
   const downloaded = br.downloadButton({
     label: 'Download Report',
     data: () => Promise.resolve(JSON.stringify({ status: 'ok' }, null, 2)),


### PR DESCRIPTION
## Problem

The `download_button` e2e spec asserted the `'Report downloaded!'` echo in the page. That echo is a deliberate one-rerun flash: the client commits value `true` (rerun → echo shows) then immediately unsets it (rerun → echo removed). Racing that transient flash made the test flaky.

## Fix

Drop the echo assertion and verify the **actual download** instead, using Playwright's `download.path()` + `readFile`:

- assert the suggested filename (`backroad-report.json`)
- assert the parsed file contents (`{ status: 'ok' }`)

This tests the real end-to-end behavior (the bytes that hit disk) rather than a UI side-effect that only momentarily exists. Also updated the now-misleading comments in the spec and the demo page.

## Verification

`npx playwright test download-button.spec.ts` → 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end testing for download functionality by validating actual downloaded file contents.

* **Documentation**
  * Updated code comments to clarify download button behavior and test validation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->